### PR TITLE
[FEAT/#10] 원형, 사각형 버튼 공통 컴포넌트 추가

### DIFF
--- a/PhotoGether/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
+++ b/PhotoGether/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05A7EFCC2CE1FF0C00DAEAAA /* PTGCircleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A7EFCB2CE1FF0C00DAEAAA /* PTGCircleButton.swift */; };
 		60F33DFC2CE1A91300A5C26D /* PTGGrayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F33DFB2CE1A91300A5C26D /* PTGGrayButton.swift */; };
 		60F33E072CE1E87000A5C26D /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F33E062CE1E87000A5C26D /* UIImage+.swift */; };
 		60F33E132CE1ED6400A5C26D /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 60F33E122CE1ED6400A5C26D /* SnapKit */; };
@@ -14,6 +15,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		05A7EFCB2CE1FF0C00DAEAAA /* PTGCircleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTGCircleButton.swift; sourceTree = "<group>"; };
 		60F33DFB2CE1A91300A5C26D /* PTGGrayButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTGGrayButton.swift; sourceTree = "<group>"; };
 		60F33E062CE1E87000A5C26D /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		7B59511B2CDB5A7000B89C85 /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -52,6 +54,7 @@
 			isa = PBXGroup;
 			children = (
 				60F33DFB2CE1A91300A5C26D /* PTGGrayButton.swift */,
+				05A7EFCB2CE1FF0C00DAEAAA /* PTGCircleButton.swift */,
 				60F33E062CE1E87000A5C26D /* UIImage+.swift */,
 				7B5951292CDB5AA700B89C85 /* Resource */,
 			);
@@ -153,6 +156,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				05A7EFCC2CE1FF0C00DAEAAA /* PTGCircleButton.swift in Sources */,
 				60F33E072CE1E87000A5C26D /* UIImage+.swift in Sources */,
 				60F33DFC2CE1A91300A5C26D /* PTGGrayButton.swift in Sources */,
 			);
@@ -164,7 +168,7 @@
 		7B5951222CDB5A7000B89C85 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -204,7 +208,7 @@
 		7B5951232CDB5A7000B89C85 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/PhotoGether/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
+++ b/PhotoGether/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		05A7EFCC2CE1FF0C00DAEAAA /* PTGCircleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A7EFCB2CE1FF0C00DAEAAA /* PTGCircleButton.swift */; };
+		05F6467D2CE2062A00694897 /* PTGPrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F6467C2CE2062A00694897 /* PTGPrimaryButton.swift */; };
 		60F33DFC2CE1A91300A5C26D /* PTGGrayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F33DFB2CE1A91300A5C26D /* PTGGrayButton.swift */; };
 		60F33E072CE1E87000A5C26D /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F33E062CE1E87000A5C26D /* UIImage+.swift */; };
 		60F33E132CE1ED6400A5C26D /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 60F33E122CE1ED6400A5C26D /* SnapKit */; };
@@ -16,6 +17,7 @@
 
 /* Begin PBXFileReference section */
 		05A7EFCB2CE1FF0C00DAEAAA /* PTGCircleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTGCircleButton.swift; sourceTree = "<group>"; };
+		05F6467C2CE2062A00694897 /* PTGPrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTGPrimaryButton.swift; sourceTree = "<group>"; };
 		60F33DFB2CE1A91300A5C26D /* PTGGrayButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTGGrayButton.swift; sourceTree = "<group>"; };
 		60F33E062CE1E87000A5C26D /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		7B59511B2CDB5A7000B89C85 /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,6 +57,7 @@
 			children = (
 				60F33DFB2CE1A91300A5C26D /* PTGGrayButton.swift */,
 				05A7EFCB2CE1FF0C00DAEAAA /* PTGCircleButton.swift */,
+				05F6467C2CE2062A00694897 /* PTGPrimaryButton.swift */,
 				60F33E062CE1E87000A5C26D /* UIImage+.swift */,
 				7B5951292CDB5AA700B89C85 /* Resource */,
 			);
@@ -156,6 +159,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				05F6467D2CE2062A00694897 /* PTGPrimaryButton.swift in Sources */,
 				05A7EFCC2CE1FF0C00DAEAAA /* PTGCircleButton.swift in Sources */,
 				60F33E072CE1E87000A5C26D /* UIImage+.swift in Sources */,
 				60F33DFC2CE1A91300A5C26D /* PTGGrayButton.swift in Sources */,

--- a/PhotoGether/DesignSystem/DesignSystem/PTGCircleButton.swift
+++ b/PhotoGether/DesignSystem/DesignSystem/PTGCircleButton.swift
@@ -1,0 +1,59 @@
+import UIKit
+import SnapKit
+
+public final class PTGCircleButton: UIButton {
+    private let type: PTGCircleButtonType
+    private let buttonImage = UIImageView()
+
+    public init(type: PTGCircleButtonType) {
+        self.type = type
+        super.init(frame: .zero)
+        
+        addViews()
+        setupConstraints()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func addViews() {
+        addSubview(buttonImage)
+    }
+    
+    private func setupConstraints() {
+        buttonImage.snp.makeConstraints {
+            $0.width.height.equalTo(24)
+            $0.center.equalToSuperview()
+        }
+    }
+    
+    private func configureUI() {
+        backgroundColor = .white
+        buttonImage.image = UIImage(systemName: type.image)
+        buttonImage.contentMode = .scaleAspectFit
+        buttonImage.tintColor = .gray90
+    }
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        self.layer.cornerRadius = self.bounds.width / 2
+    }
+}
+
+public extension PTGCircleButton {
+    enum PTGCircleButtonType {
+        case link
+        case share
+        
+        var image: String {
+            switch self {
+            case .link:
+                return "link"
+            case .share:
+                return "square.and.arrow.up"
+            }
+        }
+    }
+}

--- a/PhotoGether/DesignSystem/DesignSystem/PTGCircleButton.swift
+++ b/PhotoGether/DesignSystem/DesignSystem/PTGCircleButton.swift
@@ -38,7 +38,7 @@ public final class PTGCircleButton: UIButton {
     
     public override func layoutSubviews() {
         super.layoutSubviews()
-        self.layer.cornerRadius = self.bounds.width / 2
+        layer.cornerRadius = bounds.width / 2
     }
 }
 

--- a/PhotoGether/DesignSystem/DesignSystem/PTGPrimaryButton.swift
+++ b/PhotoGether/DesignSystem/DesignSystem/PTGPrimaryButton.swift
@@ -1,0 +1,42 @@
+import UIKit
+import SnapKit
+
+public final class PTGPrimaryButton: UIButton {
+    private let buttonLabel = UILabel()
+
+    public init() {
+        super.init(frame: .zero)
+        
+        addViews()
+        setupConstraints()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func addViews() {
+        addSubview(buttonLabel)
+    }
+    
+    private func setupConstraints() {
+        buttonLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+    
+    private func configureUI() {
+        backgroundColor = .primaryGreen
+        layer.cornerRadius = 8
+        
+        buttonLabel.font = .systemFont(ofSize: 18, weight: .regular)
+        buttonLabel.textColor = .gray85
+        buttonLabel.textAlignment = .center
+    }
+    
+    public func setTitle(to title: String) {
+        buttonLabel.text = title
+    }
+}


### PR DESCRIPTION
## 🤔 배경
- 대기, 저장 화면에서 사용되는 공통 버튼이 필요했다.

## 📃 작업 내역
- 원형 버튼 컴포넌트 추가
- 메인 컬러를 사용하는 사각 버튼 컴포넌트 추가

## ✅ 리뷰 노트
사각버튼의 `title`을 설정하기 위해서 별도의 `setTitle(to:)` 메서드를 추가했습니다. 해당 버튼의 타이틀은 대기 화면에서 인원수에 따라 변경되기 때문에 `init`에서 하는것 보다는 별도의 메서드를 두는게 맞다 판단했습니다.

## 🎨 스크린샷
| 내용 | iPhone 16 |
| :--------------: | -------------- |
| 기본 상황 | <img src = "https://github.com/user-attachments/assets/d7572834-4e8b-42bd-87c8-4b40f3102e3d" width = "280"> |
| 예외 상황 | <img src = "https://github.com/user-attachments/assets/6a8e27d2-fe3c-4006-a119-7f6dccd1d7f8" width = "280"> |


## 🚀 테스트 방법
- #9 
- 위 PR의 테스트 방법과 유사합니다