### PR TITLE
[FEAT/#12] 마이크 버튼과 TapPublisher를 구현했습니다.

### DIFF
--- a/PhotoGether/BaseFeature/BaseFeature.xcodeproj/project.pbxproj
+++ b/PhotoGether/BaseFeature/BaseFeature.xcodeproj/project.pbxproj
@@ -7,10 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		60F33E1B2CE22DAE00A5C26D /* UIControl+Publisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F33E1A2CE22DAE00A5C26D /* UIControl+Publisher.swift */; };
+		60F33E1D2CE22DB900A5C26D /* UIButton+Publisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F33E1C2CE22DB900A5C26D /* UIButton+Publisher.swift */; };
 		7B5951552CDB601900B89C85 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5951442CDB5E7100B89C85 /* BaseViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		60F33E1A2CE22DAE00A5C26D /* UIControl+Publisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+Publisher.swift"; sourceTree = "<group>"; };
+		60F33E1C2CE22DB900A5C26D /* UIButton+Publisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Publisher.swift"; sourceTree = "<group>"; };
 		7B5951382CDB5E5500B89C85 /* BaseFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BaseFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B5951442CDB5E7100B89C85 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -26,9 +30,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		60F33E192CE22D8B00A5C26D /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				60F33E1A2CE22DAE00A5C26D /* UIControl+Publisher.swift */,
+				60F33E1C2CE22DB900A5C26D /* UIButton+Publisher.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		7B59512E2CDB5E5500B89C85 = {
 			isa = PBXGroup;
 			children = (
+				60F33E192CE22D8B00A5C26D /* Extension */,
 				7B5951432CDB5E6E00B89C85 /* BaseFeature */,
 				7B5951392CDB5E5500B89C85 /* Products */,
 			);
@@ -131,6 +145,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60F33E1B2CE22DAE00A5C26D /* UIControl+Publisher.swift in Sources */,
+				60F33E1D2CE22DB900A5C26D /* UIButton+Publisher.swift in Sources */,
 				7B5951552CDB601900B89C85 /* BaseViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -153,6 +169,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -164,10 +181,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp9.BaseFeature;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -186,6 +207,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -197,10 +219,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp9.BaseFeature;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/PhotoGether/BaseFeature/Extension/UIButton+Publisher.swift
+++ b/PhotoGether/BaseFeature/Extension/UIButton+Publisher.swift
@@ -1,0 +1,10 @@
+import Combine
+import UIKit
+
+public extension UIButton {
+    var tapPublisher: AnyPublisher<Void, Never> {
+        controlPublisher(for: .touchUpInside)
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }
+}

--- a/PhotoGether/BaseFeature/Extension/UIControl+Publisher.swift
+++ b/PhotoGether/BaseFeature/Extension/UIControl+Publisher.swift
@@ -1,0 +1,49 @@
+import Combine
+import UIKit
+
+public extension UIControl {
+    /// Control Publisher
+    func controlPublisher(for event: UIControl.Event) -> UIControl.EventPublisher {
+        return UIControl.EventPublisher(control: self, event: event)
+    }
+    
+    /// Event Publisher
+    struct EventPublisher: Publisher {
+        public typealias Output = UIControl
+        public typealias Failure = Never
+        
+        let control: UIControl
+        let event: UIControl.Event
+        
+        public func receive<T>(subscriber: T) where T: Subscriber, Never == T.Failure, UIControl == T.Input {
+            let subscription = EventSubscription(control: control, subscrier: subscriber, event: event)
+            subscriber.receive(subscription: subscription)
+        }
+    }
+    
+    /// Event Subscription
+    private class EventSubscription<EventSubscriber: Subscriber>: Subscription where EventSubscriber.Input == UIControl, EventSubscriber.Failure == Never {
+        let control: UIControl
+        let event: UIControl.Event
+        var subscriber: EventSubscriber?
+        
+        init(control: UIControl, subscrier: EventSubscriber, event: UIControl.Event) {
+            self.control = control
+            self.subscriber = subscrier
+            self.event = event
+            
+            control.addTarget(self, action: #selector(eventDidOccur), for: event)
+        }
+        
+        func request(_ demand: Subscribers.Demand) {}
+        
+        func cancel() {
+            subscriber = nil
+            control.removeTarget(self, action: #selector(eventDidOccur), for: event)
+        }
+        
+        @objc func eventDidOccur() {
+            _ = subscriber?.receive(control)
+        }
+    }
+}

--- a/PhotoGether/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
+++ b/PhotoGether/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		60F33DFC2CE1A91300A5C26D /* PTGGrayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F33DFB2CE1A91300A5C26D /* PTGGrayButton.swift */; };
 		60F33E072CE1E87000A5C26D /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F33E062CE1E87000A5C26D /* UIImage+.swift */; };
 		60F33E132CE1ED6400A5C26D /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 60F33E122CE1ED6400A5C26D /* SnapKit */; };
+		60F33E152CE21EFA00A5C26D /* PTGMicButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F33E142CE21EFA00A5C26D /* PTGMicButton.swift */; };
 		7B59512B2CDB5BB500B89C85 /* DesignSystem.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B59512A2CDB5BB500B89C85 /* DesignSystem.xcassets */; };
 /* End PBXBuildFile section */
 
@@ -20,6 +21,7 @@
 		05F6467C2CE2062A00694897 /* PTGPrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTGPrimaryButton.swift; sourceTree = "<group>"; };
 		60F33DFB2CE1A91300A5C26D /* PTGGrayButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTGGrayButton.swift; sourceTree = "<group>"; };
 		60F33E062CE1E87000A5C26D /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		60F33E142CE21EFA00A5C26D /* PTGMicButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTGMicButton.swift; sourceTree = "<group>"; };
 		7B59511B2CDB5A7000B89C85 /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B59512A2CDB5BB500B89C85 /* DesignSystem.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = DesignSystem.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -55,6 +57,7 @@
 		7B5951262CDB5A7700B89C85 /* DesignSystem */ = {
 			isa = PBXGroup;
 			children = (
+				60F33E142CE21EFA00A5C26D /* PTGMicButton.swift */,
 				60F33DFB2CE1A91300A5C26D /* PTGGrayButton.swift */,
 				05A7EFCB2CE1FF0C00DAEAAA /* PTGCircleButton.swift */,
 				05F6467C2CE2062A00694897 /* PTGPrimaryButton.swift */,
@@ -163,6 +166,7 @@
 				05A7EFCC2CE1FF0C00DAEAAA /* PTGCircleButton.swift in Sources */,
 				60F33E072CE1E87000A5C26D /* UIImage+.swift in Sources */,
 				60F33DFC2CE1A91300A5C26D /* PTGGrayButton.swift in Sources */,
+				60F33E152CE21EFA00A5C26D /* PTGMicButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PhotoGether/DesignSystem/DesignSystem/PTGMicButton.swift
+++ b/PhotoGether/DesignSystem/DesignSystem/PTGMicButton.swift
@@ -1,0 +1,81 @@
+import UIKit
+import SnapKit
+
+public final class PTGMicButton: UIButton {
+    private let buttonImage = UIImageView()
+    private var micState: PTGMicState
+    
+    public init(micState: PTGMicState) {
+        self.micState = micState
+        super.init(frame: .zero)
+        
+        addViews()
+        setupConstraints()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func addViews() {
+        addSubview(buttonImage)
+    }
+    
+    private func setupConstraints() {
+        buttonImage.snp.makeConstraints {
+            $0.width.height.equalTo(24)
+            $0.center.equalToSuperview()
+        }
+    }
+    
+    private func configureUI() {
+        backgroundColor = .white.withAlphaComponent(0.2)
+        
+        buttonImage.contentMode = .scaleAspectFit
+        buttonImage.image = UIImage(systemName: micState.image)
+        buttonImage.tintColor = micState.color
+    }
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.cornerRadius = bounds.width / 2
+    }
+    
+    public func toggleMicState() {
+        switch micState {
+        case .on:
+            micState = .off
+        case .off:
+            micState = .on
+        }
+        
+        buttonImage.image = UIImage(systemName: micState.image)
+        buttonImage.tintColor = micState.color
+    }
+}
+
+public extension PTGMicButton {
+    enum PTGMicState {
+        case on
+        case off
+        
+        var image: String {
+            switch self {
+            case .on: 
+                return "microphone"
+            case .off: 
+                return "microphone.slash"
+            }
+        }
+        
+        var color: UIColor {
+            switch self {
+            case .on:
+                return .white
+            case .off:
+                return .red
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 배경
- 많은 화면에서 재활용되는 마이크 버튼 공통 컴포넌트가 필요했습니다.
- tap 하여 토글되었을 때 이벤트를 감지할 수 있도록 Combine에서 따로 지원하지 않는 TapPublisher도 필요했습니다.
<img width="198" alt="image" src="https://github.com/user-attachments/assets/269e1e1b-d7a0-49bc-959a-e01e80eb228a">

## 📃 작업 내역
- `UIControl`의 `controlPublisher()` 구현
- `UIControl`의 `Event`중 `.touchUpInside`를 감지하는 `tapPublisher`를 `UIButton`에 확장
- `PTGMicButton` 구현

## ✅ 리뷰 노트

1. `PTGMicButton`은 기본적으로 아래와 같은 프로퍼티와 메서드를 갖습니다.
```swift
public final class PTGMicButton: UIButton {
    ...
    private var micState: PTGMicState

    public func toggleMicState() { }
    ...
}
```
- `micState`는 `on/off` 상태를 가지며 `toggleMicState()`를 통해 각 state에 맞게 적절한 UI를 변경할 수 있습니다.

2. `tapPublisher`를 구현하였습니다.
```swift
        button.tapPublisher
            .sink { [weak self] _ in
                self?.button.toggleMicState()
            }.store(in: &cancellables)
```
- 위 예시처럼 사용가능합니다.

3. `controlPublisher()`를 통해 `UIControl.Event`를 구독할 수 있습니다.
```swift
        button.controlPublisher(for: .touchDown)
            .map { _ in }
            .eraseToAnyPublisher()
            .sink { [weak self] _ in
                print("touchDown")
            }.store(in: &cancellables)
        
        button.controlPublisher(for: .touchUpOutside)
            .map { _ in }
            .eraseToAnyPublisher()
            .sink { [weak self] _ in
                print("touchUpOutSide")
            }.store(in: &cancellables)
```
- `UIControl.Event`의 경우 범용적으로 많이 사용될 가능성이 있어 public으로 열어뒀습니다.


## 🎨 스크린샷
| 마이크 버튼 토글|
| -------------- |
| ![마이크버튼](https://github.com/user-attachments/assets/6d2ae68c-9938-405c-bd0d-2ca0a7c18355) |


## 🚀 테스트 방법
- 위 스크린샷은 데모를 통해 임의로 구현된 예시입니다.
- 테스트하려면 DesignSystem의 PTGMicButton 인스턴스를 선언하여 테스트 부탁드립니다.