### PR TITLE
[CHORE/#29] 설명이 명확하도록 CI yml을 수정합니다.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo ls -1 /Applications | grep "Xcode"
 
       - name: 🏷️ Select XCode 16.0
-        run: sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer
+        run: sudo xcode-select -s /Applications/Xcode_16.0.app
 
       - name: 🏷️ Show Xcode version
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: 🏷️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: 🏷️ List Xcode installations
         run: sudo ls -1 /Applications | grep "Xcode"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo ls -1 /Applications | grep "Xcode"
 
       - name: 🏷️ Select XCode 16.0
-        run: sudo xcode-select -s /Applications/Xcode_16.0.app
+        run: sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer
 
       - name: 🏷️ Show Xcode version
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   build:
-    name: ✅ CI
+    name: ✅ build
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build:
     name: ✅ build
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: 🏷️ Checkout
@@ -27,8 +27,8 @@ jobs:
       - name: 🏷️ List Xcode installations
         run: sudo ls -1 /Applications | grep "Xcode"
 
-      - name: 🏷️ Select XCode 15.4
-        run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+      - name: 🏷️ Select XCode 16.0
+        run: sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer
 
       - name: 🏷️ Show Xcode version
         run: |
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.DERIVED_DATA_PATH }}
-          key: ${{ runner.os }}-iOS_derived_data-xcode_15.4
+          key: ${{ runner.os }}-iOS_derived_data-xcode_16.0
           restore-keys: |
             ${{ runner.os }}-iOS_derived_data-
       

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,8 +27,8 @@ jobs:
       - name: 🏷️ List Xcode installations
         run: sudo ls -1 /Applications | grep "Xcode"
 
-      - name: 🏷️ Select XCode 16.0
-        run: sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer
+      - name: 🏷️ Select XCode 15.4
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
 
       - name: 🏷️ Show Xcode version
         run: |
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.DERIVED_DATA_PATH }}
-          key: ${{ runner.os }}-iOS_derived_data-xcode_16.0
+          key: ${{ runner.os }}-iOS_derived_data-xcode_15.4
           restore-keys: |
             ${{ runner.os }}-iOS_derived_data-
       


### PR DESCRIPTION
## 🤔 배경

<img width="353" alt="image" src="https://github.com/user-attachments/assets/f3baa040-8a89-455a-9f24-00d064ed22fa">

CI CI 라고 뜨는게 불명확해 CI에서 뭘 테스트돌리고 있는건데? 라고 생각이 들 수 있는 부분이라, CI Build 이렇게 뜨도록 변경했습니다.


## 📃 작업 내역

- job name 변경 
  - ✅ CI -> ✅ build

- XCode 버전을 찾지 못하는 문제 수정

### XCode 버전을 찾지 못하는 문제 수정

runner os 를 macos-latest 로 해두면, 릴리즈된 os image 중 최신 image를 사용합니다.
따라서 아래 사진처럼 현재 릴리즈된 최신 os인 14.7.1이 선택됩니다.

<img width="355" alt="image" src="https://github.com/user-attachments/assets/162fb283-f879-490f-af2d-7e804201465b">

하지만 14.7.1에는 XCode 16.0 이상이 없습니다.
(XCode 16.0 이후 버전은 macOS 15.0 이상에서만 사용할 수 있어서 그런듯)

<img width="397" alt="image" src="https://github.com/user-attachments/assets/df7f8bfa-bf81-4aff-874e-eb4cc9720908">

사용가능한 XCode 버전 목록에 16.0이 없기 때문에 찾을 수 없는 문제가 발생했습니다.
 
<img width="776" alt="image" src="https://github.com/user-attachments/assets/609f5019-e13c-4b3a-81d1-661bc77d600f">

그러면 Github Action에선 XCode 16.0 대응이 안되어있는건가? 싶어서 Github Action Runner에서 사용가능한 macOS 버전을 찾아보았습니다. 

그리고 현재 macOS 15.0은 퍼블릭 베타(의역) 으로 배포되어 있는 것 같았습니다.

<img width="742" alt="image" src="https://github.com/user-attachments/assets/abff61e8-a121-4181-8434-e0d1acbbd473">

그래서 macos-latest 를 macos-15 로 바꾸어 runner OS를 명시적으로 macOS 15.0를 바꾸도록 해 문제를 해결했습니다.

### runner-images 버전 참고 링크
https://docs.github.com/ko/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners
https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
