### PR TITLE
[FEAT/#27] SharePhotoView UI를 구현합니다.

### DIFF
--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature.xcodeproj/project.pbxproj
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		055503C22CDB55F5004D34EB /* SharePhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055503C02CDB5589004D34EB /* SharePhotoViewController.swift */; };
 		055503C42CDB5608004D34EB /* SharePhotoFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 055503882CDB54AF004D34EB /* SharePhotoFeature.framework */; };
 		055503C52CDB5608004D34EB /* SharePhotoFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 055503882CDB54AF004D34EB /* SharePhotoFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		60B03BF12CE4CE3100A7C748 /* SharePhotoBottomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B03BF02CE4CE3100A7C748 /* SharePhotoBottomView.swift */; };
+		60B03BF32CE4CEDC00A7C748 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60B03BF22CE4CEDC00A7C748 /* DesignSystem.framework */; };
+		60B03BF42CE4CEDC00A7C748 /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 60B03BF22CE4CEDC00A7C748 /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B59510F2CDB598E00B89C85 /* FeatureTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B59510E2CDB598E00B89C85 /* FeatureTesting.framework */; };
 		7B5951102CDB598E00B89C85 /* FeatureTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B59510E2CDB598E00B89C85 /* FeatureTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B5951522CDB600100B89C85 /* BaseFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5951512CDB600100B89C85 /* BaseFeature.framework */; };
@@ -51,6 +54,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				60B03BF42CE4CEDC00A7C748 /* DesignSystem.framework in Embed Frameworks */,
 				7B5951D32CDB664300B89C85 /* PhotoGetherDomainInterface.framework in Embed Frameworks */,
 				7B5951532CDB600100B89C85 /* BaseFeature.framework in Embed Frameworks */,
 			);
@@ -68,6 +72,8 @@
 		055503B02CDB5500004D34EB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		055503B42CDB5500004D34EB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		055503C02CDB5589004D34EB /* SharePhotoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePhotoViewController.swift; sourceTree = "<group>"; };
+		60B03BF02CE4CE3100A7C748 /* SharePhotoBottomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePhotoBottomView.swift; sourceTree = "<group>"; };
+		60B03BF22CE4CEDC00A7C748 /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B59510E2CDB598E00B89C85 /* FeatureTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FeatureTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B5951512CDB600100B89C85 /* BaseFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BaseFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B59517A2CDB62A600B89C85 /* PresentationUtility.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PresentationUtility.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -79,6 +85,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60B03BF32CE4CEDC00A7C748 /* DesignSystem.framework in Frameworks */,
 				7B5951D22CDB664300B89C85 /* PhotoGetherDomainInterface.framework in Frameworks */,
 				7B5951522CDB600100B89C85 /* BaseFeature.framework in Frameworks */,
 			);
@@ -155,6 +162,7 @@
 			isa = PBXGroup;
 			children = (
 				055503C02CDB5589004D34EB /* SharePhotoViewController.swift */,
+				60B03BF02CE4CE3100A7C748 /* SharePhotoBottomView.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -162,6 +170,7 @@
 		055503C32CDB5608004D34EB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				60B03BF22CE4CEDC00A7C748 /* DesignSystem.framework */,
 				7B5951D12CDB664300B89C85 /* PhotoGetherDomainInterface.framework */,
 				7B59517A2CDB62A600B89C85 /* PresentationUtility.framework */,
 				7B5951512CDB600100B89C85 /* BaseFeature.framework */,
@@ -287,6 +296,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60B03BF12CE4CE3100A7C748 /* SharePhotoBottomView.swift in Sources */,
 				055503C22CDB55F5004D34EB /* SharePhotoViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -325,7 +335,7 @@
 		0555038F2CDB54AF004D34EB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -363,7 +373,7 @@
 		055503902CDB54AF004D34EB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoBottomView.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoBottomView.swift
@@ -1,0 +1,54 @@
+import Combine
+import DesignSystem
+import UIKit
+
+final class SharePhotoBottomView: UIView {
+    private let shareButton = PTGCircleButton(type: .share)
+    private let saveButton = PTGPrimaryButton()
+    
+    var shareButtonTapped: AnyPublisher<Void, Never> {
+        return shareButton.tapPublisher
+    }
+    
+    var saveButtonTapped: AnyPublisher<Void, Never> {
+        return saveButton.tapPublisher
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addViews()
+        setupConstraints()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    private func addViews() {
+        [shareButton, saveButton].forEach {
+            addSubview($0)
+        }
+    }
+    
+    private func setupConstraints() {
+        shareButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.verticalEdges.equalToSuperview().inset(14)
+            $0.width.height.equalTo(52)
+        }
+        
+        saveButton.snp.makeConstraints {
+            $0.leading.equalTo(shareButton.snp.trailing).offset(16)
+            $0.verticalEdges.equalTo(shareButton)
+            $0.trailing.equalToSuperview().inset(16)
+        }
+    }
+    
+    private func configureUI() {
+        backgroundColor = .clear
+        saveButton.setTitle(to: "저장하기")
+    }
+}

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewController.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewController.swift
@@ -1,6 +1,13 @@
+import BaseFeature
+import Combine
+import DesignSystem
 import UIKit
 
-public class SharePhotoViewController: UIViewController {
+public class SharePhotoViewController: BaseViewController {
+    private let navigationView = UIView()
+    private let photoView = UIImageView()
+    private let bottomView = SharePhotoBottomView()
+    
     public init() {
         super.init(nibName: nil, bundle: nil)
     }
@@ -11,6 +18,74 @@ public class SharePhotoViewController: UIViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .cyan
+        
+        addViews()
+        setupConstraints()
+        configureUI()
+        bindOutput()
+    }
+    
+    public override func addViews() {
+        [navigationView, photoView, bottomView].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    public override func setupConstraints() {
+        navigationView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(48)
+        }
+        
+        photoView.snp.makeConstraints {
+            $0.top.equalTo(navigationView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(bottomView.snp.top)
+        }
+        
+        bottomView.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(80)
+        }
+    }
+    
+    // MARK: Image가 원래는 바인딩 되어야 함
+    public override func configureUI() {
+        view.backgroundColor = PTGColor.gray90.color
+        
+        photoView.image = PTGImage.frameIcon.image
+        photoView.backgroundColor = PTGColor.gray50.color
+        photoView.contentMode = .scaleAspectFit
+    }
+    
+    public override func bindOutput() {
+        bottomView.shareButtonTapped
+            .sink { [weak self] _ in
+                self?.showShareSheet()
+            }
+            .store(in: &cancellables)
+        
+        bottomView.saveButtonTapped
+            .sink { [weak self] _ in
+                self?.saveImage()
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func showShareSheet() {
+        if let image = photoView.image {
+            let activityViewController = UIActivityViewController(
+                activityItems: [image],
+                applicationActivities: nil
+            )
+            present(activityViewController, animated: true)
+        }
+    }
+    
+    // TODO: 권한 요청 및 사진앱에 저장
+    private func saveImage() {
+        
     }
 }


### PR DESCRIPTION
## 🤔 배경
편집이 완료된 이미지를 확인하고 해당 이미지를 저장하고, 공유할 수 있는 UI가 필요했습니다.

## 📃 작업 내역

- 해당화면의 BottomView UI 작업
- 추후 UI Binding을 할 수 있도록 서브뷰의 필요한 프로퍼티의 접근제어 확인
- #31 

## ✅ 리뷰 노트
무지성 Input-Output transform을 했다가 너무 쓸모가 없어서 일단 ViewController만 두었습니다.
추후 ViewModel이 필요해지고, 편집화면의 Image가 넘어오는 등의 로직이 구체화되면 고민해볼 예정입니다.

앨범 저장시 권한설정에 대한 로직을 어디서 담당하는게 좋을까요?

## 🎨 스크린샷
https://github.com/user-attachments/assets/d8f671ec-9527-4c88-887d-c9f73ee89f6f

## 🚀 테스트 방법
- SharePhotoFeatureDemo 실행

close #27  #31 