### PR TITLE
[REFACTOR/#34] BaseViewController의 메소드를 프로토콜로 분리해주었습니다.

### DIFF
--- a/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/BaseViewController.swift
+++ b/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/BaseViewController.swift
@@ -4,9 +4,17 @@ import Combine
 open class BaseViewController: UIViewController {
     public var cancellables = Set<AnyCancellable>()
     let customNavigationBar = UIView()
-    
-    open func addViews() { }
-    open func setupConstraints() { }
-    open func configureUI() { }
-    open func bindOutput() { }
+}
+
+public protocol ViewControllerConfigure {
+    func addViews()
+    func setupConstraints()
+    func configureUI()
+    func bindInput()
+    func bindOutput()
+}
+
+public extension ViewControllerConfigure {
+    func bindInput() { }
+    func bindOutput() { }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature.xcodeproj/project.pbxproj
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		053DC8512CE32A8800DC9F35 /* EditPhotoHostBottomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053DC8502CE32A8800DC9F35 /* EditPhotoHostBottomView.swift */; };
 		053DC8532CE32AE900DC9F35 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 053DC8522CE32AE900DC9F35 /* DesignSystem.framework */; };
 		053DC8542CE32AE900DC9F35 /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 053DC8522CE32AE900DC9F35 /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		05729E032CE5998C005F6994 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 05729E022CE5998C005F6994 /* Secrets.xcconfig */; };
 		05C297562CE391FF00108687 /* CanvasScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C297552CE391FF00108687 /* CanvasScrollView.swift */; };
 		60B03BDF2CE3810200A7C748 /* FrameImageGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B03BDE2CE3810200A7C748 /* FrameImageGenerator.swift */; };
 		60B03BE22CE43FAF00A7C748 /* FrameImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B03BE12CE43FAF00A7C748 /* FrameImageView.swift */; };
@@ -74,7 +75,7 @@
 /* Begin PBXFileReference section */
 		053DC8502CE32A8800DC9F35 /* EditPhotoHostBottomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPhotoHostBottomView.swift; sourceTree = "<group>"; };
 		053DC8522CE32AE900DC9F35 /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-
+		05729E022CE5998C005F6994 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		05C297552CE391FF00108687 /* CanvasScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasScrollView.swift; sourceTree = "<group>"; };
 		60B03BDE2CE3810200A7C748 /* FrameImageGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameImageGenerator.swift; sourceTree = "<group>"; };
 		60B03BE12CE43FAF00A7C748 /* FrameImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameImageView.swift; sourceTree = "<group>"; };
@@ -206,6 +207,7 @@
 		60CB82A32CDB50CA00873DD6 /* Resource */ = {
 			isa = PBXGroup;
 			children = (
+				05729E022CE5998C005F6994 /* Secrets.xcconfig */,
 				60CB82922CDB509200873DD6 /* Assets.xcassets */,
 				60CB82932CDB509200873DD6 /* Info.plist */,
 				60CB82952CDB509200873DD6 /* LaunchScreen.storyboard */,
@@ -343,6 +345,7 @@
 			files = (
 				60CB829E2CDB509200873DD6 /* Assets.xcassets in Resources */,
 				60CB82A02CDB509200873DD6 /* LaunchScreen.storyboard in Resources */,
+				05729E032CE5998C005F6994 /* Secrets.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import BaseFeature
 
-public class EditPhotoRoomHostViewController: BaseViewController, UIScrollViewDelegate {
+public class EditPhotoRoomHostViewController: BaseViewController, ViewControllerConfigure, UIScrollViewDelegate {
     private let bottomView = EditPhotoHostBottomView()
     private let navigationView = UIView()
     private let canvasScrollView = CanvasScrollView()
@@ -30,13 +30,13 @@ public class EditPhotoRoomHostViewController: BaseViewController, UIScrollViewDe
         canvasScrollView.contentCentering()
     }
     
-    public override func addViews() {
+    public func addViews() {
         [navigationView, canvasScrollView, bottomView].forEach {
             view.addSubview($0)
         }
     }
     
-    public override func setupConstraints() {
+    public func setupConstraints() {
         navigationView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.horizontalEdges.equalToSuperview()
@@ -57,7 +57,7 @@ public class EditPhotoRoomHostViewController: BaseViewController, UIScrollViewDe
     }
     
     // TODO: 디자인 시스템에 컬러 에셋 추가 후 구현 예정
-    public override func configureUI() {
+    public func configureUI() {
         
     }
     

--- a/PhotoGether/PresentationLayer/PhotoRoomFeature/PhotoRoomFeature.xcodeproj/project.pbxproj
+++ b/PhotoGether/PresentationLayer/PhotoRoomFeature/PhotoRoomFeature.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05729E012CE59967005F6994 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 05729E002CE59967005F6994 /* Secrets.xcconfig */; };
 		60CB82472CDA4BBC00873DD6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CB823D2CDA4BBC00873DD6 /* AppDelegate.swift */; };
 		60CB82482CDA4BBC00873DD6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CB82442CDA4BBC00873DD6 /* SceneDelegate.swift */; };
 		60CB824A2CDA4BBC00873DD6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60CB823E2CDA4BBC00873DD6 /* Assets.xcassets */; };
@@ -60,6 +61,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		05729E002CE59967005F6994 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		60CB820E2CDA4B5E00873DD6 /* PhotoRoomFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PhotoRoomFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		60CB82222CDA4B7F00873DD6 /* PhotoRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRoomViewController.swift; sourceTree = "<group>"; };
 		60CB82282CDA4BB000873DD6 /* PhotoRoomFeatureDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoRoomFeatureDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -154,6 +156,7 @@
 		60CB82552CDA4DA200873DD6 /* Resource */ = {
 			isa = PBXGroup;
 			children = (
+				05729E002CE59967005F6994 /* Secrets.xcconfig */,
 				60CB823E2CDA4BBC00873DD6 /* Assets.xcassets */,
 				60CB823F2CDA4BBC00873DD6 /* Info.plist */,
 				60CB82412CDA4BBC00873DD6 /* LaunchScreen.storyboard */,
@@ -277,6 +280,7 @@
 			files = (
 				60CB824A2CDA4BBC00873DD6 /* Assets.xcassets in Resources */,
 				60CB824C2CDA4BBC00873DD6 /* LaunchScreen.storyboard in Resources */,
+				05729E012CE59967005F6994 /* Secrets.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PhotoGether/PresentationLayer/PhotoRoomFeature/PhotoRoomFeature/Source/PhotoRoomViewController.swift
+++ b/PhotoGether/PresentationLayer/PhotoRoomFeature/PhotoRoomFeature/Source/PhotoRoomViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import BaseFeature
 import Combine
 
-public class PhotoRoomViewController: BaseViewController {
+public class PhotoRoomViewController: BaseViewController, ViewControllerConfigure {
     public init() {
         super.init(nibName: nil, bundle: nil)
     }
@@ -15,4 +15,11 @@ public class PhotoRoomViewController: BaseViewController {
         super.viewDidLoad()
         view.backgroundColor = .blue
     }
+    
+    public func addViews() { }
+    
+    public func setupConstraints() { }
+    
+    public func configureUI() { }
+    
 }

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewController.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewController.swift
@@ -3,7 +3,7 @@ import Combine
 import DesignSystem
 import UIKit
 
-public class SharePhotoViewController: BaseViewController {
+public class SharePhotoViewController: BaseViewController, ViewControllerConfigure {
     private let navigationView = UIView()
     private let photoView = UIImageView()
     private let bottomView = SharePhotoBottomView()
@@ -25,13 +25,13 @@ public class SharePhotoViewController: BaseViewController {
         bindOutput()
     }
     
-    public override func addViews() {
+    public func addViews() {
         [navigationView, photoView, bottomView].forEach {
             view.addSubview($0)
         }
     }
     
-    public override func setupConstraints() {
+    public func setupConstraints() {
         navigationView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.horizontalEdges.equalToSuperview()
@@ -52,7 +52,7 @@ public class SharePhotoViewController: BaseViewController {
     }
     
     // MARK: Image가 원래는 바인딩 되어야 함
-    public override func configureUI() {
+    public func configureUI() {
         view.backgroundColor = PTGColor.gray90.color
         
         photoView.image = PTGImage.frameIcon.image
@@ -60,7 +60,7 @@ public class SharePhotoViewController: BaseViewController {
         photoView.contentMode = .scaleAspectFit
     }
     
-    public override func bindOutput() {
+    public func bindOutput() {
         bottomView.shareButtonTapped
             .sink { [weak self] _ in
                 self?.showShareSheet()

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/WaitingRoomViewController.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/WaitingRoomViewController.swift
@@ -4,7 +4,7 @@ import PhotoGetherDomainInterface
 import SnapKit
 import UIKit
 
-public class WaitingRoomViewController: BaseViewController {
+public class WaitingRoomViewController: BaseViewController, ViewControllerConfigure {
     let connectionClient: ConnectionClient
     let offerButton = UIButton()
     let localVideoView: UIView
@@ -31,13 +31,13 @@ public class WaitingRoomViewController: BaseViewController {
         setActions()
     }
     
-    public override func addViews() {
+    public func addViews() {
         [offerButton, localVideoView, remoteVideoView].forEach { subView in
             view.addSubview(subView)
         }
     }
     
-    public override func setupConstraints() {
+    public func setupConstraints() {
         offerButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(20)
             $0.centerX.equalToSuperview()
@@ -60,7 +60,7 @@ public class WaitingRoomViewController: BaseViewController {
         }
     }
     
-    public override func configureUI() {
+    public func configureUI() {
         view.backgroundColor = .white
         
         offerButton.setTitle("Offer", for: .normal)


### PR DESCRIPTION
## 🤔 배경
기본으로 사용해야 될 메소드들을 자동완성 될 수 있도록 프로토콜로 만들었습니다.

## 📃 작업 내역
- BaseViewController 분리
- 기존 BaseViewController를 상속받던 ViewController들에 프로토콜을 채택하도록 수정

## ✅ 리뷰 노트
라이브 코드 리뷰

## 🎨 스크린샷
라이브 코드 리뷰


## 🚀 테스트 방법
라이브 코드 리뷰
