### PR TITLE
[FEAT/#51] :: HTTP API를 추상화합니다.

### DIFF
--- a/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/APIError.swift
+++ b/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/APIError.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+public enum APIError: Error {
+    case unknown
+    case custom(message: String = "알 수 없는 오류가 발생하였습니다", code: Int = 999)
+    case timeout
+    case decodingError(DecodingError)
+    case badRequest       // 400번대 오류
+    case unauthorized     // 401 Unauthorized
+    case forbidden        // 403 Forbidden
+    case notFound         // 404 Not Found
+    case serverError      // 500번대 오류
+}
+
+extension APIError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unknown:
+            return "알 수 없는 오류가 발생하였습니다."
+        case let .custom(message, _):
+            return message
+        case .timeout:
+            return "타임 아웃 에러입니다."
+        case let .decodingError(error):
+            return error.fullDescription
+        case .badRequest:
+            return "잘못된 요청입니다."
+        case .unauthorized:
+            return "인증 오류입니다."
+        case .forbidden:
+            return "권한 없음입니다."
+        case .notFound:
+            return "요청한 것을 찾을 수 없습니다."
+        case .serverError:
+            return "서버 오류입니다."
+        }
+    }
+}
+
+extension Error {
+    public var asAPIError: APIError {
+        if let decodingError = self.asDecodingError {
+            return APIError.decodingError(decodingError)
+        } else if let urlError = self.asURLError, urlError.code == .timedOut {
+            return APIError.timeout
+        } else {
+            return self as? APIError ?? .unknown
+        }
+    }
+    
+    var asDecodingError: DecodingError? {
+        return self as? DecodingError
+    }
+    
+    var asURLError: URLError? {
+        return self as? URLError
+    }
+}
+
+extension DecodingError {
+    var fullDescription: String {
+        switch self {
+        case let .typeMismatch(type, context):
+            return """
+                    타입이 맞지 않습니다.\n
+                    \(type) 타입에서 오류 발생:\n
+                    codingPath: \(context.codingPath)\n
+                    debugDescription: \(context.debugDescription)\n
+                    underlyingError: \(context.underlyingError?.localizedDescription ?? "none")
+                    """
+        case let .valueNotFound(type, context):
+            return """
+                    값을 찾을 수 없습니다.\n
+                    \(type) 타입에서 오류 발생:\n
+                    codingPath: \(context.codingPath)\n
+                    debugDescription: \(context.debugDescription)\n
+                    underlyingError: \(context.underlyingError?.localizedDescription ?? "none")
+                    """
+        case let .keyNotFound(key, context):
+            return """
+                    키 \(key) 를 찾을 수 없습니다:\n
+                    codingPath: \(context.codingPath)\n
+                    debugDescription: \(context.debugDescription)\n
+                    underlyingError: \(context.underlyingError?.localizedDescription ?? "none")
+                    """
+        case let .dataCorrupted(context):
+            return """
+                    데이터 손실 에러입니다.\n
+                    codingPath: \(context.codingPath)\n
+                    debugDescription: \(context.debugDescription)\n
+                    underlyingError: \(context.underlyingError?.localizedDescription ?? "none")
+                    """
+        default:
+            return "알 수 없는 디코딩에 실패했습니다."
+        }
+    }
+}

--- a/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/EndPoint.swift
+++ b/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/EndPoint.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public enum HTTPMethod: String {
+    case get = "GET"
+}
+
+public protocol EndPoint {
+    var baseURL: URL { get }
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var parameters: [String: Any]? { get }
+    var headers: [String: String]? { get }
+    var body: Encodable? { get }
+}
+
+extension EndPoint {
+    public func request() -> URLRequest {
+        var url = baseURL.appendingPathComponent(path)
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        
+        urlComponents.queryItems = parameters?.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+        url = urlComponents.url!
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+        
+        headers?.forEach {
+            request.setValue($0.value, forHTTPHeaderField: $0.key)
+        }
+                
+        if let body, let jsonData = try? JSONEncoder().encode(body) {
+            request.httpBody = jsonData
+        }
+        
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        
+        return request
+    }
+}

--- a/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/Request.swift
+++ b/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/Request.swift
@@ -20,7 +20,10 @@ public enum Request {
             .eraseToAnyPublisher()
     }
     
-    public static func requestVoid<E: EndPoint>(_ endPoint: E, queue: DispatchQueue = .main) -> AnyPublisher<Void, any Error> {
+    public static func requestVoid<E: EndPoint>(
+        _ endPoint: E,
+        queue: DispatchQueue = .main
+    ) -> AnyPublisher<Void, any Error> {
         return URLSession.shared.dataTaskPublisher(for: endPoint.request())
             .timeout(.seconds(10), scheduler: RunLoop.main)
             .map { output in
@@ -95,8 +98,7 @@ private extension Request {
         // Response Body 출력
         print("\n====================[ Response Body ]====================\n")
         if let bodyString = String(data: output.data, encoding: .utf8) {
-//            print("\(bodyString)")
-            print("count:\(bodyString.count)")
+            print("\(bodyString)")
         } else {
             print("Unable to encode utf8")
         }

--- a/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/Request.swift
+++ b/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/Request.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Combine
+
+public enum Request {
+    public static func requestJSON<E: EndPoint, T: Decodable>(
+        _ endPoint: E,
+        decoder: JSONDecoder = .init(),
+        queue: DispatchQueue = .main
+    ) -> AnyPublisher<T, any Error> {
+        decoder.dateDecodingStrategy = .iso8601
+        return URLSession.shared.dataTaskPublisher(for: endPoint.request())
+            .timeout(.seconds(10), scheduler: RunLoop.main)
+            .map { output in
+                printNetworkLog(request: endPoint.request(), output: output)
+            }
+            .tryMap(responseToData)
+            .decode(type: T.self, decoder: decoder)
+            .mapError(\.asAPIError)
+            .receive(on: queue)
+            .eraseToAnyPublisher()
+    }
+    
+    public static func requestVoid<E: EndPoint>(_ endPoint: E, queue: DispatchQueue = .main) -> AnyPublisher<Void, any Error> {
+        return URLSession.shared.dataTaskPublisher(for: endPoint.request())
+            .timeout(.seconds(10), scheduler: RunLoop.main)
+            .map { output in
+                printNetworkLog(request: endPoint.request(), output: output)
+            }
+            .tryMap(responseToData)
+            .map { _ in () }
+            .mapError(\.asAPIError)
+            .receive(on: queue)
+            .eraseToAnyPublisher()
+    }
+}
+
+private extension Request {
+    static func responseToData(_ output: URLSession.DataTaskPublisher.Output) throws -> Data {
+        guard let httpResponse = output.response as? HTTPURLResponse else {
+            throw APIError.custom(message: "응답이 없습니다.", code: 999)
+        }
+        
+        switch httpResponse.statusCode {
+        case 200...299:
+            return output.data
+        case 400:
+            throw APIError.badRequest
+        case 401:
+            throw APIError.unauthorized
+        case 403:
+            throw APIError.forbidden
+        case 404:
+            throw APIError.notFound
+        case 500...599:
+            throw APIError.serverError
+        default:
+            throw APIError.unknown
+        }
+    }
+    
+    static func printNetworkLog(request: URLRequest, output: URLSession.DataTaskPublisher.Output) -> URLSession.DataTaskPublisher.Output {
+        // Request 정보 출력
+        let method = request.httpMethod ?? "unknown method"
+        let url = request.url?.absoluteString ?? "Unknown URL"
+        
+        print("====================\n\n[\(method)] \(url)\n\n====================\n")
+        
+        print("====================[ Request Headers ]====================\n")
+        
+        if let headers = request.allHTTPHeaderFields {
+            print("\(headers)")
+        } else {
+            print("header를 찾을 수 없습니다.")
+        }
+        
+        print("\n====================[ End Request Headers ]====================\n")
+        
+        // Request Body 출력
+        print("\n====================[ Request Body ]====================\n")
+        
+        if let body = request.httpBody, let bodyString = String(data: body, encoding: .utf8) {
+            print("\(bodyString)")
+        } else {
+            print("Unable to encode utf8")
+        }
+        
+        print("\n====================[ End Request Body ]====================\n")
+        
+        // Response 정보 출력
+        let httpResponse = output.response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? -1
+                
+        print("====================\n\n[\(statusCode)]\n[\(url)]\n\n====================\n")
+        
+        // Response Body 출력
+        print("\n====================[ Response Body ]====================\n")
+        if let bodyString = String(data: output.data, encoding: .utf8) {
+//            print("\(bodyString)")
+            print("count:\(bodyString.count)")
+        } else {
+            print("Unable to encode utf8")
+        }
+        print("\n====================[ End Body ]====================\n")
+        
+        return output
+    }
+}


### PR DESCRIPTION
## 🤔 배경
- https://github.com/boostcampwm-2024/iOS04-PhotoGether/issues/51
스티커 API들을 사용하기 위해 HTTP 통신 메소드가 필요했고, 여러 API가 존재할 수 있어 추상화를 진행했습니다.

## 📃 작업 내역
- enum Request 추가

```swift
// 사용 방법
Request.requestJSON(IssueAPI.fetchIssues(page: page))

// 구현부
public enum Request {
    public static func requestJSON<E: EndPoint, T: Decodable>(
        _ endPoint: E,
        decoder: JSONDecoder = .init(),
        queue: DispatchQueue = .main
    ) -> AnyPublisher<T, any Error> {
        return URLSession.shared.dataTaskPublisher(for: endPoint.request())
             // 10초의 타임아웃을 적용
            .timeout(.seconds(10), scheduler: RunLoop.main)
            .map { output in
               // 네트워크 로그를 출력
                printNetworkLog(request: endPoint.request(), output: output)
            }
            // Response -> Data 변환
            .tryMap(responseToData)
            // Data -> JSON 변환
            .decode(type: T.self, decoder: decoder)
            // Error 처리
            .mapError(\.asAPIError)
            // Queue 선택 옵션
            .receive(on: queue)
            .eraseToAnyPublisher()
    }
}
```

- enum EndPoint 추가

서드파티 라이브러리인 Moya 방식에서 영감을 받아 EndPoint protocol로 추상화했습니다.
EndPoint 프로토콜을 채택하여 구현하고 `request()` 메소드를 통해 URLRequest 로 변환할 수 있도록 합니다.

```swift
public protocol EndPoint {
    var baseURL: URL { get }
    var path: String { get }
    var method: HTTPMethod { get }
    var parameters: [String: Any]? { get }
    var headers: [String: String]? { get }
    var body: Encodable? { get }
}

extension EndPoint {
    public func request() -> URLRequest { ... }

```


- enum APIError 추가

네트워킹 중 발생하는 에러를 구분하기위해 Enum으로 관리합니다.
```swift
public enum APIError: Error {
    case decodingError(DecodingError)
    case badRequest       // 400번대 오류
    ...
}

extension APIError: LocalizedError {
    public var errorDescription: String? {
        switch self {
        case .unknown:
            return "알 수 없는 오류가 발생하였습니다."
        ...
        }
    }
}

```
디코딩 에러 메시지를 직관적으로 볼 수 있도록 프로퍼티를 추가합니다.
```swift
extension DecodingError {
    var fullDescription: String {
        switch self {
        case let .typeMismatch(type, context):
            return """
                    타입이 맞지 않습니다.\n
                    \(type) 타입에서 오류 발생:\n
                    codingPath: \(context.codingPath)\n
                    debugDescription: \(context.debugDescription)\n
                    underlyingError: \(context.underlyingError?.localizedDescription ?? "none")
                    """
        ...
```



## ✅ 리뷰 노트


## 🎨 스크린샷
- nil 😨

## 🚀 테스트 방법
- nil 🤯
