### PR TITLE
[FEAT/#59] EditPhotoRoomGuestView UI 및 스티커 생성 로직 구현

### DIFF
--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature.xcodeproj/project.pbxproj
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature.xcodeproj/project.pbxproj
@@ -9,16 +9,6 @@
 /* Begin PBXBuildFile section */
 		053DC8532CE32AE900DC9F35 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 053DC8522CE32AE900DC9F35 /* DesignSystem.framework */; };
 		053DC8542CE32AE900DC9F35 /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 053DC8522CE32AE900DC9F35 /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		055AF9732CEC6E7A0060E408 /* PhotoGetherDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 055AF9722CEC6E7A0060E408 /* PhotoGetherDomain.framework */; };
-		055AF9742CEC6E7A0060E408 /* PhotoGetherDomain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 055AF9722CEC6E7A0060E408 /* PhotoGetherDomain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		055AF9762CEC6E7F0060E408 /* PhotoGetherDomainInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 055AF9752CEC6E7F0060E408 /* PhotoGetherDomainInterface.framework */; };
-		055AF9772CEC6E7F0060E408 /* PhotoGetherDomainInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 055AF9752CEC6E7F0060E408 /* PhotoGetherDomainInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		055AF9792CEC6E840060E408 /* PhotoGetherDomainTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 055AF9782CEC6E840060E408 /* PhotoGetherDomainTesting.framework */; };
-		055AF97A2CEC6E840060E408 /* PhotoGetherDomainTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 055AF9782CEC6E840060E408 /* PhotoGetherDomainTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		055AF9A72CEC739C0060E408 /* FeatureTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 055AF9A62CEC739C0060E408 /* FeatureTesting.framework */; };
-		055AF9A82CEC739C0060E408 /* FeatureTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 055AF9A62CEC739C0060E408 /* FeatureTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		055AF9A92CEC73B20060E408 /* EditPhotoRoomFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60CB82612CDB4FC500873DD6 /* EditPhotoRoomFeature.framework */; };
-		055AF9AA2CEC73B20060E408 /* EditPhotoRoomFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 60CB82612CDB4FC500873DD6 /* EditPhotoRoomFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		60CB82A82CDB522900873DD6 /* EditPhotoRoomFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60CB82612CDB4FC500873DD6 /* EditPhotoRoomFeature.framework */; };
 		60CB82A92CDB522900873DD6 /* EditPhotoRoomFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 60CB82612CDB4FC500873DD6 /* EditPhotoRoomFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B59510C2CDB598600B89C85 /* FeatureTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B59510B2CDB598600B89C85 /* FeatureTesting.framework */; };
@@ -30,13 +20,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		055AF9AB2CEC73B20060E408 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 60CB82582CDB4FC500873DD6 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 60CB82602CDB4FC500873DD6;
-			remoteInfo = EditPhotoRoomFeature;
-		};
 		60CB82AA2CDB522900873DD6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 60CB82582CDB4FC500873DD6 /* Project object */;
@@ -47,18 +30,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		055AF9A12CEC6F4A0060E408 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				055AF9A82CEC739C0060E408 /* FeatureTesting.framework in Embed Frameworks */,
-				055AF9AA2CEC73B20060E408 /* EditPhotoRoomFeature.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		60CB82AC2CDB522900873DD6 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -66,10 +37,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				7B59510D2CDB598600B89C85 /* FeatureTesting.framework in Embed Frameworks */,
-				055AF97A2CEC6E840060E408 /* PhotoGetherDomainTesting.framework in Embed Frameworks */,
 				60CB82A92CDB522900873DD6 /* EditPhotoRoomFeature.framework in Embed Frameworks */,
-				055AF9772CEC6E7F0060E408 /* PhotoGetherDomainInterface.framework in Embed Frameworks */,
-				055AF9742CEC6E7A0060E408 /* PhotoGetherDomain.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -91,14 +59,6 @@
 
 /* Begin PBXFileReference section */
 		053DC8522CE32AE900DC9F35 /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		055AF9722CEC6E7A0060E408 /* PhotoGetherDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		055AF9752CEC6E7F0060E408 /* PhotoGetherDomainInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherDomainInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		055AF9782CEC6E840060E408 /* PhotoGetherDomainTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherDomainTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		055AF9892CEC6F0B0060E408 /* PhotoGetherDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		055AF98D2CEC6F0E0060E408 /* PhotoGetherDomainInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherDomainInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		055AF9942CEC6F430060E408 /* EditPhotoRoomHostViewModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EditPhotoRoomHostViewModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		055AF99E2CEC6F4A0060E408 /* PhotoGetherDomainInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherDomainInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		055AF9A62CEC739C0060E408 /* FeatureTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FeatureTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		60CB82612CDB4FC500873DD6 /* EditPhotoRoomFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EditPhotoRoomFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		60CB827C2CDB508C00873DD6 /* EditPhotoRoomFeatureDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EditPhotoRoomFeatureDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B59510B2CDB598600B89C85 /* FeatureTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FeatureTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -118,11 +78,6 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		055AF9952CEC6F430060E408 /* EditPhotoRoomHostViewModelTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = EditPhotoRoomHostViewModelTests;
-			sourceTree = "<group>";
-		};
 		7B1746AC2CE8E9C900E01D1A /* EditPhotoRoomFeature */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = EditPhotoRoomFeature;
@@ -139,15 +94,6 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		055AF9912CEC6F430060E408 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				055AF9A72CEC739C0060E408 /* FeatureTesting.framework in Frameworks */,
-				055AF9A92CEC73B20060E408 /* EditPhotoRoomFeature.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		60CB825E2CDB4FC500873DD6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -163,10 +109,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B59510C2CDB598600B89C85 /* FeatureTesting.framework in Frameworks */,
-				055AF9792CEC6E840060E408 /* PhotoGetherDomainTesting.framework in Frameworks */,
 				60CB82A82CDB522900873DD6 /* EditPhotoRoomFeature.framework in Frameworks */,
-				055AF9762CEC6E7F0060E408 /* PhotoGetherDomainInterface.framework in Frameworks */,
-				055AF9732CEC6E7A0060E408 /* PhotoGetherDomain.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -178,7 +121,6 @@
 			children = (
 				7B1746AC2CE8E9C900E01D1A /* EditPhotoRoomFeature */,
 				7B1746D22CE8E9D400E01D1A /* EditPhotoRoomFeatureDemo */,
-				055AF9952CEC6F430060E408 /* EditPhotoRoomHostViewModelTests */,
 				60CB82A72CDB522900873DD6 /* Frameworks */,
 				60CB82622CDB4FC500873DD6 /* Products */,
 			);
@@ -189,7 +131,6 @@
 			children = (
 				60CB82612CDB4FC500873DD6 /* EditPhotoRoomFeature.framework */,
 				60CB827C2CDB508C00873DD6 /* EditPhotoRoomFeatureDemo.app */,
-				055AF9942CEC6F430060E408 /* EditPhotoRoomHostViewModelTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -197,13 +138,6 @@
 		60CB82A72CDB522900873DD6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				055AF9A62CEC739C0060E408 /* FeatureTesting.framework */,
-				055AF99E2CEC6F4A0060E408 /* PhotoGetherDomainInterface.framework */,
-				055AF98D2CEC6F0E0060E408 /* PhotoGetherDomainInterface.framework */,
-				055AF9892CEC6F0B0060E408 /* PhotoGetherDomain.framework */,
-				055AF9782CEC6E840060E408 /* PhotoGetherDomainTesting.framework */,
-				055AF9752CEC6E7F0060E408 /* PhotoGetherDomainInterface.framework */,
-				055AF9722CEC6E7A0060E408 /* PhotoGetherDomain.framework */,
 				053DC8522CE32AE900DC9F35 /* DesignSystem.framework */,
 				7B5951CE2CDB658400B89C85 /* PhotoGetherDomainInterface.framework */,
 				7B5951772CDB62A200B89C85 /* PresentationUtility.framework */,
@@ -226,30 +160,6 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		055AF9932CEC6F430060E408 /* EditPhotoRoomHostViewModelTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 055AF99B2CEC6F430060E408 /* Build configuration list for PBXNativeTarget "EditPhotoRoomHostViewModelTests" */;
-			buildPhases = (
-				055AF9902CEC6F430060E408 /* Sources */,
-				055AF9912CEC6F430060E408 /* Frameworks */,
-				055AF9922CEC6F430060E408 /* Resources */,
-				055AF9A12CEC6F4A0060E408 /* Embed Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				055AF9AC2CEC73B20060E408 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				055AF9952CEC6F430060E408 /* EditPhotoRoomHostViewModelTests */,
-			);
-			name = EditPhotoRoomHostViewModelTests;
-			packageProductDependencies = (
-			);
-			productName = EditPhotoRoomHostViewModelTests;
-			productReference = 055AF9942CEC6F430060E408 /* EditPhotoRoomHostViewModelTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		60CB82602CDB4FC500873DD6 /* EditPhotoRoomFeature */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 60CB82672CDB4FC500873DD6 /* Build configuration list for PBXNativeTarget "EditPhotoRoomFeature" */;
@@ -308,9 +218,6 @@
 				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
-					055AF9932CEC6F430060E408 = {
-						CreatedOnToolsVersion = 16.0;
-					};
 					60CB82602CDB4FC500873DD6 = {
 						CreatedOnToolsVersion = 16.0;
 					};
@@ -335,19 +242,11 @@
 			targets = (
 				60CB82602CDB4FC500873DD6 /* EditPhotoRoomFeature */,
 				60CB827B2CDB508C00873DD6 /* EditPhotoRoomFeatureDemo */,
-				055AF9932CEC6F430060E408 /* EditPhotoRoomHostViewModelTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		055AF9922CEC6F430060E408 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		60CB825F2CDB4FC500873DD6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -365,13 +264,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		055AF9902CEC6F430060E408 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		60CB825D2CDB4FC500873DD6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -389,11 +281,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		055AF9AC2CEC73B20060E408 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 60CB82602CDB4FC500873DD6 /* EditPhotoRoomFeature */;
-			targetProxy = 055AF9AB2CEC73B20060E408 /* PBXContainerItemProxy */;
-		};
 		60CB82AB2CDB522900873DD6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 60CB82602CDB4FC500873DD6 /* EditPhotoRoomFeature */;
@@ -402,48 +289,6 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		055AF99C2CEC6F430060E408 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B3PWYBKFUK;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.boostcamp9.EditPhotoRoomHostViewModelTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-			};
-			name = Debug;
-		};
-		055AF99D2CEC6F430060E408 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B3PWYBKFUK;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.boostcamp9.EditPhotoRoomHostViewModelTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-			};
-			name = Release;
-		};
 		60CB82682CDB4FC500873DD6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -522,6 +367,8 @@
 		};
 		60CB826A2CDB4FC500873DD6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 7B1746D22CE8E9D400E01D1A /* EditPhotoRoomFeatureDemo */;
+			baseConfigurationReferenceRelativePath = Resource/Secrets.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -714,15 +561,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		055AF99B2CEC6F430060E408 /* Build configuration list for PBXNativeTarget "EditPhotoRoomHostViewModelTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				055AF99C2CEC6F430060E408 /* Debug */,
-				055AF99D2CEC6F430060E408 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		60CB825B2CDB4FC500873DD6 /* Build configuration list for PBXProject "EditPhotoRoomFeature" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoGuestBottomView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoGuestBottomView.swift
@@ -23,9 +23,11 @@ final class EditPhotoGuestBottomView: UIView {
         configureUI()
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
     
     private func addViews() {
         addSubview(stackView)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoGuestBottomView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoGuestBottomView.swift
@@ -27,7 +27,6 @@ final class EditPhotoGuestBottomView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
     
     private func addViews() {
         addSubview(stackView)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoGuestBottomView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoGuestBottomView.swift
@@ -1,0 +1,53 @@
+import UIKit
+import Combine
+import DesignSystem
+
+final class EditPhotoGuestBottomView: UIView {
+    private let stackView = UIStackView()
+    private let frameButton = PTGGrayButton(type: .frame)
+    private let stickerButton = PTGGrayButton(type: .sticker)
+    
+    var frameButtonTapped: AnyPublisher<Void, Never> {
+        return frameButton.tapPublisher
+    }
+    
+    var stickerButtonTapped: AnyPublisher<Void, Never> {
+        return stickerButton.tapPublisher
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addViews()
+        setupConstraints()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func addViews() {
+        addSubview(stackView)
+        
+        [frameButton, stickerButton].forEach {
+            stackView.addArrangedSubview($0)
+        }
+    }
+    
+    private func setupConstraints() {
+        stackView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(32)
+            $0.verticalEdges.equalToSuperview().inset(14)
+        }
+    }
+    
+    // TODO: nextButton background primaryColor로 변경 예정
+    private func configureUI() {
+        backgroundColor = .clear
+        
+        stackView.spacing = 16
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+    }
+}

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
@@ -1,0 +1,124 @@
+import UIKit
+import Combine
+import BaseFeature
+import DesignSystem
+
+public class EditPhotoRoomGuestViewController: BaseViewController, ViewControllerConfigure {
+    private let navigationView = UIView()
+    private let canvasScrollView = CanvasScrollView()
+    private let bottomView = EditPhotoGuestBottomView()
+    
+    private let input = PassthroughSubject<EditPhotoRoomGuestViewModel.Input, Never>()
+    
+    private let viewModel: EditPhotoRoomGuestViewModel
+    
+    public init(viewModel: EditPhotoRoomGuestViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        addViews()
+        setupConstraints()
+        configureUI()
+        bindInput()
+        bindOutput()
+    }
+    
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        canvasScrollView.setupZoomScale()
+        canvasScrollView.contentCentering()
+    }
+    
+    public func addViews() {
+        [navigationView, canvasScrollView, bottomView].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    public func setupConstraints() {
+        navigationView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(48)
+        }
+        
+        canvasScrollView.snp.makeConstraints {
+            $0.top.equalTo(navigationView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(bottomView.snp.top)
+        }
+        
+        bottomView.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(80)
+        }
+    }
+    
+    public func configureUI() {
+        view.backgroundColor = .brown
+        
+        navigationView.backgroundColor = .yellow
+        bottomView.backgroundColor = .yellow
+        canvasScrollView.backgroundColor = .red
+        
+        canvasScrollView.imageView.sizeToFit()
+    }
+    
+    public func bindInput() {
+        bottomView.stickerButtonTapped
+            .sink { [weak self] in
+                self?.input.send(.stickerButtonDidTap)
+            }
+            .store(in: &cancellables)
+    }
+    
+    public func bindOutput() {
+        let output = viewModel.transform(input: input.eraseToAnyPublisher())
+        
+        output.sink { [weak self] in
+            switch $0 {
+            case .sticker(let data):
+                self?.renderSticker(data: data)
+            }
+        }
+        .store(in: &cancellables)
+    }
+    
+    private func renderSticker(data: Data) {
+        let imageSize: CGFloat = 60
+        let rect = calculateCenterPosition(imageSize: imageSize)
+        let stickerImageView = UIImageView(frame: rect)
+        let stickerImage = UIImage(data: data)
+        
+        stickerImageView.image = stickerImage
+        
+        canvasScrollView.imageView.addSubview(stickerImageView)
+    }
+    
+    private func calculateCenterPosition(imageSize: CGFloat) -> CGRect {
+        let zoomScale = canvasScrollView.zoomScale
+        let bounds = canvasScrollView.bounds
+        
+        let centerX = bounds.midX / zoomScale
+        let centerY = bounds.midY / zoomScale
+        
+        let size = imageSize / sqrt(zoomScale)
+        
+        return CGRect(
+            x: centerX - size / 2,
+            y: centerY - size / 2,
+            width: size,
+            height: size
+        )
+    }
+}

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
@@ -18,6 +18,7 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
         super.init(nibName: nil, bundle: nil)
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Combine
+import PhotoGetherDomainInterface
+
+public final class EditPhotoRoomGuestViewModel {
+    enum Input {
+        case stickerButtonDidTap
+    }
+
+    enum Output {
+        case sticker(data: Data)
+    }
+    
+    private let fetchStickerListUseCase: FetchStickerListUseCase
+    private var stickerList: [Data] = []
+    
+    private var cancellables = Set<AnyCancellable>()
+    private var output = PassthroughSubject<Output, Never>()
+    
+    public init(
+        fetchStickerListUseCase: FetchStickerListUseCase
+    ) {
+        self.fetchStickerListUseCase = fetchStickerListUseCase
+        bind()
+    }
+    
+    private func bind() {
+        fetchStickerList()
+    }
+    
+    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
+        input.sink { [weak self] in
+            switch $0 {
+            case .stickerButtonDidTap:
+                self?.addStickerToCanvas()
+            }
+        }
+        .store(in: &cancellables)
+        
+        return output.eraseToAnyPublisher()
+    }
+    
+    private func fetchStickerList() {
+        fetchStickerListUseCase.execute()
+            .sink { [weak self] datas in
+                self?.stickerList = datas
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func addStickerToCanvas() {
+        output.send(.sticker(data: stickerList.randomElement()!))
+    }
+}

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/Resource/Info.plist
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/Resource/Info.plist
@@ -19,5 +19,7 @@
 			</array>
 		</dict>
 	</dict>
+	<key>BASE_URL</key>
+	<string>$(BASE_URL)</string>
 </dict>
 </plist>

--- a/PhotoGether/PresentationLayer/FeatureTesting/FeatureTesting.xcodeproj/project.pbxproj
+++ b/PhotoGether/PresentationLayer/FeatureTesting/FeatureTesting.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		608ED9B02CED9E3900A2577E /* PhotoGetherDomainInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 608ED9AF2CED9E3900A2577E /* PhotoGetherDomainInterface.framework */; };
+		608ED9B12CED9E3900A2577E /* PhotoGetherDomainInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 608ED9AF2CED9E3900A2577E /* PhotoGetherDomainInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		608ED9B32CED9E3F00A2577E /* PhotoGetherDomainTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 608ED9B22CED9E3F00A2577E /* PhotoGetherDomainTesting.framework */; };
+		608ED9B42CED9E3F00A2577E /* PhotoGetherDomainTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 608ED9B22CED9E3F00A2577E /* PhotoGetherDomainTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B5950F82CDB590C00B89C85 /* EditPhotoRoomFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5950F42CDB590C00B89C85 /* EditPhotoRoomFeature.framework */; };
 		7B5950F92CDB590C00B89C85 /* EditPhotoRoomFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5950F42CDB590C00B89C85 /* EditPhotoRoomFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B5950FA2CDB590C00B89C85 /* PhotoRoomFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5950F52CDB590C00B89C85 /* PhotoRoomFeature.framework */; };
@@ -27,6 +31,8 @@
 				7B5950FF2CDB590C00B89C85 /* WaitingRoomFeature.framework in Embed Frameworks */,
 				7B5950F92CDB590C00B89C85 /* EditPhotoRoomFeature.framework in Embed Frameworks */,
 				7B5950FB2CDB590C00B89C85 /* PhotoRoomFeature.framework in Embed Frameworks */,
+				608ED9B42CED9E3F00A2577E /* PhotoGetherDomainTesting.framework in Embed Frameworks */,
+				608ED9B12CED9E3900A2577E /* PhotoGetherDomainInterface.framework in Embed Frameworks */,
 				7B5950FD2CDB590C00B89C85 /* SharePhotoFeature.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -35,6 +41,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		608ED9AF2CED9E3900A2577E /* PhotoGetherDomainInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherDomainInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		608ED9B22CED9E3F00A2577E /* PhotoGetherDomainTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherDomainTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B5950E72CDB58F000B89C85 /* FeatureTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FeatureTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B5950F42CDB590C00B89C85 /* EditPhotoRoomFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EditPhotoRoomFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B5950F52CDB590C00B89C85 /* PhotoRoomFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoRoomFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -58,6 +66,8 @@
 				7B5950FE2CDB590C00B89C85 /* WaitingRoomFeature.framework in Frameworks */,
 				7B5950F82CDB590C00B89C85 /* EditPhotoRoomFeature.framework in Frameworks */,
 				7B5950FA2CDB590C00B89C85 /* PhotoRoomFeature.framework in Frameworks */,
+				608ED9B32CED9E3F00A2577E /* PhotoGetherDomainTesting.framework in Frameworks */,
+				608ED9B02CED9E3900A2577E /* PhotoGetherDomainInterface.framework in Frameworks */,
 				7B5950FC2CDB590C00B89C85 /* SharePhotoFeature.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -85,6 +95,8 @@
 		7B5950F32CDB590C00B89C85 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				608ED9B22CED9E3F00A2577E /* PhotoGetherDomainTesting.framework */,
+				608ED9AF2CED9E3900A2577E /* PhotoGetherDomainInterface.framework */,
 				7B5950F42CDB590C00B89C85 /* EditPhotoRoomFeature.framework */,
 				7B5950F52CDB590C00B89C85 /* PhotoRoomFeature.framework */,
 				7B5950F62CDB590C00B89C85 /* SharePhotoFeature.framework */,


### PR DESCRIPTION
## 🤔 배경
EditPhotoRoomGuestViewController에서는 EditPhotoRoomGuestViewModel의 StickerObjectList를 구독하여 ImageView를 생성하고 업데이트 할 수 있어야한다.

## 📃 작업 내역
- VC에서는 StickerImage와 Rect의 계산을 통해 StickerObject를 만들어서 ViewModel에 전달합니다.
- 스티커 생성 시 ViewModel은 해당 StickerObject를 StickerObjectListSubject(DataSource 역할)에 추가합니다.
- VC는 DataSource를 통해 CanvasView의 ImageView(Sticker를 표현하는)를 CRUD합니다. (현재는 C,R,U만 가능)
- 이때 StickerObject의 id(UUID)와 canvasView.imageView.subviews의 index로 key-value 딕셔너리를 통해 추가적인 리소스 없이 StickerObject를 표현하는 ImageView를 참조할 수 있습니다.
- Dictionary를 통해 StickerObject를 표현하는 ImageView를 생성 또는 변경이 가능합니다.

## ✅ 리뷰 노트

### StickerObject
현재 StickerObject는 ViewModel에 아래와 같이 존재하며 프로퍼티는 추후 확정 예정입니다.
DomainInterface로 옮겨질 예정입니다.
```swift
struct StickerObject {
    let id: UUID
    let image: Data
    let rect: CGRect
}
```

### StickerObjectListSubject
```swift
   private var stickerObjectListSubject = CurrentValueSubject<[StickerObject], Never>([])

   ...

   private func bind() {
        fetchStickerList()
        
        stickerObjectListSubject
            .sink { [weak self] list in
                self?.output.send(.stickerObjectList(list))
            }
            .store(in: &cancellables)
    }

    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
        input.sink { [weak self] event in
            switch event {
            case .stickerButtonDidTap:
                self?.sendStickerImage()
            case .stickerObjectData(let sticker):
                self?.appendSticker(with: sticker)
            }
        }
        .store(in: &cancellables)
        
        return output.eraseToAnyPublisher()
    }
    
    private func appendSticker(with sticker: StickerObject) {
        var currentStickerObjectList = stickerObjectListSubject.value
        currentStickerObjectList.append(sticker)
        stickerObjectListSubject.send(currentStickerObjectList)
    }
```
- stickerObjectListSubject를 CurrentValueSubject로 두었습니다.
- `@Published`는 다른 Combine의 Subject들과 달리 스트림을 함께 관리하기에 적합하지 않아서 배제하였습니다.
- 빈번한 스티커의 추가/삭제 작업이 예상되는 상황에서, value 프로퍼티를 통해 값을 참조하고 즉시 수정할 수 있기 때문에 선택했습니다.
상태 관리와 변화 감지(스트림 방출)를 동시에 처리하기에 적합합니다.
- 현재는 초깃값 빈 배열 이벤트 방출이 쓸모 없는게 맞습니다. 다만, Frame의 경우 초깃값 방출이 필요하기 때문에 모든 EventHub에서 관리하는 값을 통합적으로 DataSource로 쓴다면 초깃값 방출은 추후 유용하게 쓰일 예정입니다.

### 이벤트 흐름
1. VC에서 스티커 버튼 탭 → Input으로 ViewModel에 이벤트 전달.
2. ViewModel → 스티커 이미지 URL을 Output으로 방출.
3. VC → URL을 받아 CGRect 계산 후 스티커 데이터를 생성해 Input으로 ViewModel에 전달.
4. ViewModel → 스티커 데이터를 배열에 저장하고 배열 변경 이벤트를 방출.
5. VC → 스티커 배열을 구독하여 UIImageView를 업데이트.

- ImageView는 유일하게 ViewModel의 DataSource를 바라보며 업데이트 하기 위해 초기에는 이벤트 흐름이 다소 복잡해보일 수 있습니다.

## 🎨 스크린샷
X


## 🚀 테스트 방법
EditPhotoFeatureDemo에서 GuestViewController로 rootViewController로 설정하여 실행
