### PR TITLE
[FEAT/#62] 스티커 API 연결 및 Entity에 맞게 일부 코드 수정

### DIFF
--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/LocalShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/LocalShapeDataSourceImpl.swift
@@ -1,0 +1,11 @@
+import Combine
+import Foundation
+import PhotoGetherDomainInterface
+
+public final class LocalShapeDataSourceImpl: ShapeDataSource {
+    public func fetchStickerData() -> AnyPublisher<[StickerDTO], Error> {
+        return Empty().eraseToAnyPublisher()
+    }
+    
+    public init() { }
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
@@ -17,6 +17,9 @@ private struct StickerEndPoint: EndPoint {
     var method: HTTPMethod { .get }
     // 시작 인덱스, 1회 호출당 30개씩 호출
     var parameters: [String: Any]? { ["group": "objects", "offset": 0] }
-    var headers: [String: String]? { ["X-Api-Key": "N5d5CSI9fhzP7bhTmydbpQ==Rc4jeybVfDReMxGo"] }
+    var headers: [String: String]? {
+        let apiKey = Bundle.main.object(forInfoDictionaryKey: "EMOJI_API_KEY") as? String ?? ""
+        return ["X-Api-Key": apiKey]
+    }
     var body: Encodable? { nil }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
@@ -1,0 +1,22 @@
+import Combine
+import Foundation
+import PhotoGetherNetwork
+
+public final class RemoteShapeDataSourceImpl: ShapeDataSource {
+    // TODO: 페이징 적용 필요
+    public func fetchStickerData() -> AnyPublisher<[StickerDTO], Error> {
+        return Request.requestJSON(StickerEndPoint())
+    }
+    
+    public init() { }
+}
+
+private struct StickerEndPoint: EndPoint {
+    var baseURL: URL { URL(string: "https://api.api-ninjas.com")! }
+    var path: String { "v1/emoji" }
+    var method: HTTPMethod { .get }
+    // 시작 인덱스, 1회 호출당 30개씩 호출
+    var parameters: [String: Any]? { ["group": "objects", "offset": 0] }
+    var headers: [String: String]? { ["X-Api-Key": "N5d5CSI9fhzP7bhTmydbpQ==Rc4jeybVfDReMxGo"] }
+    var body: Encodable? { nil }
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeDataSource.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeDataSource.swift
@@ -1,0 +1,6 @@
+import Combine
+import Foundation
+
+public protocol ShapeDataSource {
+    func fetchStickerData() -> AnyPublisher<[StickerDTO], Error>
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
@@ -1,0 +1,25 @@
+import Combine
+import Foundation
+import PhotoGetherDomainInterface
+
+final public class ShapeRepositoryImpl: ShapeRepository {
+    // TODO: local 먼저 확인 -> remote 데이터 확인하도록 수정
+    // MARK: JSON 데이터 내부의 URL을 어느 시점에 다운로드 할것인가...?
+    public func fetchStickerList() -> AnyPublisher<[StickerEntity], Never> {
+        return remoteDataSource.fetchStickerData()
+            .map { $0.map { $0.toEntity() } }
+            .replaceError(with: [])
+            .eraseToAnyPublisher()
+    }
+    
+    private let localDataSource: ShapeDataSource
+    private let remoteDataSource: ShapeDataSource
+    
+    public init(
+        localDataSource: ShapeDataSource,
+        remoteDataSource: ShapeDataSource
+    ) {
+        self.localDataSource = localDataSource
+        self.remoteDataSource = remoteDataSource
+    }
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/StickerDTO.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/StickerDTO.swift
@@ -1,0 +1,20 @@
+import Foundation
+import PhotoGetherDomainInterface
+
+public struct StickerDTO: Decodable {
+    let code: String
+    let character: String
+    let image: String
+    let name: String
+    let group: String
+    let subgroup: String
+}
+
+extension StickerDTO {
+    func toEntity() -> StickerEntity {
+        return .init(
+            image: self.image,
+            name: self.name
+        )    
+    }
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Temp.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Temp.swift
@@ -1,6 +1,0 @@
-import Foundation
-import DataUtility
-
-public func hello() -> String {
-    return "hello"
-}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/FetchStickerListUseCaseTests/FetchStickerListUseCaseTests.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/FetchStickerListUseCaseTests/FetchStickerListUseCaseTests.swift
@@ -28,20 +28,20 @@ final class FetchStickerListUseCaseTests: XCTestCase {
         
         sut = FetchStickerListUseCaseImpl(shapeRepository: shapeRepositoryMock)
         
-        var targetDataList: [Data] = []
-        let beforeDataListCount = 0
+        var targetEntityList: [StickerEntity] = []
+        let beforeEntityListCount = 0
         
         //Act 실행 단계: SUT 메소드를 호출하면서 의존성을 전달해서 결과를 저장하기
         let cancellable = sut.execute()
-            .sink { datas in
-                targetDataList.append(contentsOf: datas)
+            .sink { stickerEntities in
+                targetEntityList.append(contentsOf: stickerEntities)
                 expectation.fulfill()
             }
         
         //Assert 검증 단계: 결과와 기대치를 비교해서 검증하기
         wait(for: [expectation], timeout: 2.0)
-        XCTAssertEqual(beforeDataListCount, 0)
-        XCTAssertEqual(targetDataList.count, 12)
+        XCTAssertEqual(beforeEntityListCount, 0)
+        XCTAssertEqual(targetEntityList.count, 12)
         
         cancellable.cancel()
     }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/FetchStickerListUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/FetchStickerListUseCaseImpl.swift
@@ -3,7 +3,7 @@ import Foundation
 import PhotoGetherDomainInterface
 
 public final class FetchStickerListUseCaseImpl: FetchStickerListUseCase {
-    public func execute() -> AnyPublisher<[Data], Never> {
+    public func execute() -> AnyPublisher<[StickerEntity], Never> {
         return shapeRepository.fetchStickerList()
     }
     

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Model/StickerEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Model/StickerEntity.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct StickerEntity: Decodable {
+public struct StickerEntity {
     public let image: String
     public let name: String
    

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Model/StickerEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Model/StickerEntity.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct StickerEntity: Decodable {
+    public let image: String
+    public let name: String
+   
+    public init(image: String, name: String) {
+        self.image = image
+        self.name = name
+    }
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/ShapeRepository.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/ShapeRepository.swift
@@ -2,5 +2,5 @@ import Combine
 import Foundation
 
 public protocol ShapeRepository {
-    func fetchStickerList() -> AnyPublisher<[Data], Never>
+    func fetchStickerList() -> AnyPublisher<[StickerEntity], Never>
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/FetchStickerListUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/FetchStickerListUseCase.swift
@@ -2,5 +2,5 @@ import Combine
 import Foundation
 
 public protocol FetchStickerListUseCase {
-    func execute() -> AnyPublisher<[Data], Never>
+    func execute() -> AnyPublisher<[StickerEntity], Never>
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainTesting/ShapeRepositoryMock.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainTesting/ShapeRepositoryMock.swift
@@ -9,19 +9,22 @@ public final class ShapeRepositoryMock: ShapeRepository {
         self.imageNameList = imageNameList
     }
     
-    public func fetchStickerList() -> AnyPublisher<[Data], Never> {
-        let imageDataList = imageNameList.map { imageData(named: $0) }
+    public func fetchStickerList() -> AnyPublisher<[StickerEntity], Never> {
+        let stickerEntities: [StickerEntity] = imageNameList.map {
+            .init(
+                image: imageData(named: $0),    // 이미지 주소(or 경로)
+                name: $0
+            )
+        }
         
-        return Just(imageDataList.compactMap { $0 })
-            .eraseToAnyPublisher()
+        return Just(stickerEntities).eraseToAnyPublisher()
     }
     
-    private func imageData(named: String) -> Data? {
+    private func imageData(named: String) -> String {
         let bundle = Bundle(for: Self.self) // 해당 클래스가 존재하는 Bundle을 의미
-        guard let imageURL = bundle.url(forResource: named, withExtension: "png"),
-              let imageData = try? Data(contentsOf: imageURL)
-        else { debugPrint("bundle Image to Data error"); return nil }
+        guard let path = bundle.url(forResource: named, withExtension: "png")?.absoluteString
+        else { return "" }
         
-        return imageData
+        return path
     }
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainTesting/ShapeRepositoryMock.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainTesting/ShapeRepositoryMock.swift
@@ -12,7 +12,7 @@ public final class ShapeRepositoryMock: ShapeRepository {
     public func fetchStickerList() -> AnyPublisher<[StickerEntity], Never> {
         let stickerEntities: [StickerEntity] = imageNameList.map {
             .init(
-                image: imageData(named: $0),    // 이미지 주소(or 경로)
+                image: imagePath(named: $0),    // 이미지 주소(or 경로)
                 name: $0
             )
         }
@@ -20,7 +20,7 @@ public final class ShapeRepositoryMock: ShapeRepository {
         return Just(stickerEntities).eraseToAnyPublisher()
     }
     
-    private func imageData(named: String) -> String {
+    private func imagePath(named: String) -> String {
         let bundle = Bundle(for: Self.self) // 해당 클래스가 존재하는 Bundle을 의미
         guard let path = bundle.url(forResource: named, withExtension: "png")?.absoluteString
         else { return "" }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature.xcodeproj/project.pbxproj
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature.xcodeproj/project.pbxproj
@@ -528,6 +528,8 @@
 		};
 		60CB826A2CDB4FC500873DD6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 7B1746D22CE8E9D400E01D1A /* EditPhotoRoomFeatureDemo */;
+			baseConfigurationReferenceRelativePath = Resource/Secrets.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature.xcodeproj/project.pbxproj
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		050F6E122CEE19A2002F5473 /* PhotoGetherData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 050F6E112CEE19A2002F5473 /* PhotoGetherData.framework */; };
+		050F6E132CEE19A2002F5473 /* PhotoGetherData.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 050F6E112CEE19A2002F5473 /* PhotoGetherData.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		053DC8532CE32AE900DC9F35 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 053DC8522CE32AE900DC9F35 /* DesignSystem.framework */; };
 		053DC8542CE32AE900DC9F35 /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 053DC8522CE32AE900DC9F35 /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		055AF9732CEC6E7A0060E408 /* PhotoGetherDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 055AF9722CEC6E7A0060E408 /* PhotoGetherDomain.framework */; };
@@ -65,6 +67,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				050F6E132CEE19A2002F5473 /* PhotoGetherData.framework in Embed Frameworks */,
 				7B59510D2CDB598600B89C85 /* FeatureTesting.framework in Embed Frameworks */,
 				055AF97A2CEC6E840060E408 /* PhotoGetherDomainTesting.framework in Embed Frameworks */,
 				60CB82A92CDB522900873DD6 /* EditPhotoRoomFeature.framework in Embed Frameworks */,
@@ -90,6 +93,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		050F6E112CEE19A2002F5473 /* PhotoGetherData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		053DC8522CE32AE900DC9F35 /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		055AF9722CEC6E7A0060E408 /* PhotoGetherDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		055AF9752CEC6E7F0060E408 /* PhotoGetherDomainInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherDomainInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -162,6 +166,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				050F6E122CEE19A2002F5473 /* PhotoGetherData.framework in Frameworks */,
 				7B59510C2CDB598600B89C85 /* FeatureTesting.framework in Frameworks */,
 				055AF9792CEC6E840060E408 /* PhotoGetherDomainTesting.framework in Frameworks */,
 				60CB82A82CDB522900873DD6 /* EditPhotoRoomFeature.framework in Frameworks */,
@@ -197,6 +202,7 @@
 		60CB82A72CDB522900873DD6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				050F6E112CEE19A2002F5473 /* PhotoGetherData.framework */,
 				055AF9A62CEC739C0060E408 /* FeatureTesting.framework */,
 				055AF99E2CEC6F4A0060E408 /* PhotoGetherDomainInterface.framework */,
 				055AF98D2CEC6F0E0060E408 /* PhotoGetherDomainInterface.framework */,

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -8,11 +8,11 @@ public final class EditPhotoRoomHostViewModel {
     }
 
     enum Output {
-        case sticker(data: Data)
+        case sticker(entity: StickerEntity)
     }
     
     private let fetchStickerListUseCase: FetchStickerListUseCase
-    private var stickerList: [Data] = []
+    private var stickerList: [StickerEntity] = []
     
     private var cancellables = Set<AnyCancellable>()
     private var output = PassthroughSubject<Output, Never>()
@@ -42,13 +42,13 @@ public final class EditPhotoRoomHostViewModel {
     
     private func fetchStickerList() {
         fetchStickerListUseCase.execute()
-            .sink { [weak self] datas in
-                self?.stickerList = datas
+            .sink { [weak self] stickerEntities in
+                self?.stickerList = stickerEntities
             }
             .store(in: &cancellables)
     }
     
     private func addStickerToCanvas() {
-        output.send(.sticker(data: stickerList.randomElement()!))
+        output.send(.sticker(entity: stickerList.randomElement()!))
     }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import EditPhotoRoomFeature
+import PhotoGetherData
 import PhotoGetherDomainInterface
 import PhotoGetherDomain
 import PhotoGetherDomainTesting
@@ -28,8 +29,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             "sunglasses",
             "tree",
         ]
-        let shapeRepositoryMock = ShapeRepositoryMock(imageNameList: imageNameList)
-        let fetchStickerListUseCase = FetchStickerListUseCaseImpl(shapeRepository: shapeRepositoryMock)
+        
+        // TODO: 추후 Data 의존성 제거 및 Mock으로 전환
+//        let shapeRepositoryMock = ShapeRepositoryMock(imageNameList: imageNameList)
+        let localDataSource = LocalShapeDataSourceImpl()
+        let remoteDataSource = RemoteShapeDataSourceImpl()
+        let shapeRepositoryImpl = ShapeRepositoryImpl(localDataSource: localDataSource, remoteDataSource: remoteDataSource)
+        let fetchStickerListUseCase = FetchStickerListUseCaseImpl(shapeRepository: shapeRepositoryImpl)
         let editPhotoRoomHostViewModel = EditPhotoRoomHostViewModel(fetchStickerListUseCase: fetchStickerListUseCase)
         let editPhotoRoomHostViewController = EditPhotoRoomHostViewController(viewModel: editPhotoRoomHostViewModel)
         window?.rootViewController = editPhotoRoomHostViewController

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/Resource/Info.plist
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/Resource/Info.plist
@@ -19,5 +19,7 @@
 			</array>
 		</dict>
 	</dict>
+	<key>EMOJI_API_KEY</key>
+	<string>$(EMOJI_API_KEY)</string>
 </dict>
 </plist>

--- a/PhotoGether/PresentationLayer/FeatureTesting/FeatureTesting/FetchStickerListUseCaseMock.swift
+++ b/PhotoGether/PresentationLayer/FeatureTesting/FeatureTesting/FetchStickerListUseCaseMock.swift
@@ -13,7 +13,7 @@ public final class FetchStickerListUseCaseMock: FetchStickerListUseCase {
     
     public init() { }
     
-    public func execute() -> AnyPublisher<[Data], Never> {
+    public func execute() -> AnyPublisher<[StickerEntity], Never> {
         return repository.fetchStickerList()
     }
 }


### PR DESCRIPTION
## 🤔 배경
- 스티커 API 연결이 필요했습니다.

## 📃 작업 내역
- 필요한 DataSource, Repository를 추가로 구현하였습니다.
- 스티커 API를 위한 DTO, Entity도 추가하였습니다.

## ✅ 리뷰 노트
3-layer-architechture에 기반하여 동작할 수 있도록 fetchSticker를 설계했습니다. 

이 부분에서 조금 러닝 커브가 발생하였어서 후반 커밋은 @hsw1920 님과  같이 설계를 했습니다.

스스로 구현하면서도 부족함이 느껴져서 조금이라도 수정하거나, 

좀 더 좋은 스타일이 있는지 봐주시며 피드백 해주시면 감사하겠습니다!

## 🎨 스크린샷
| iPhone SE(2세대) | iPhone 14 | iPhone 16 Pro Max |
| -------------- | -------------- | -------------- |
| ![iPhonse SE 2nd gen](https://github.com/user-attachments/assets/80cb1dc9-d7e6-4fcf-b5b4-4db848a1cf64) | ![iPhone 14](https://github.com/user-attachments/assets/fd30904a-500b-404f-b25e-36a88739089c) | ![iPhone 16 Pro Max](https://github.com/user-attachments/assets/ef67b713-e2f1-41bb-8126-30f0b437938b) |


## 🚀 테스트 방법
EditPhotoRoomFeatureDemo 앱을 실행한 뒤 스티커 버튼을 누르면 랜덤한 스티커를 가져옵니다.
