### PR TITLE
[FEAT/#74] DiffableDataSource snapshot을 수정할 때 발생하던 경고 문제 수정

### DIFF
--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/WaitingRoomViewController.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/WaitingRoomViewController.swift
@@ -93,17 +93,21 @@ public final class WaitingRoomViewController: BaseViewController, ViewController
         
         output.localVideo.sink { [weak self] localVideoView in
             guard let self else { return }
+            
             var snapshot = self.participantsCollectionViewController.dataSource.snapshot()
             var items = snapshot.itemIdentifiers
-            
-            var newItem = SectionItem(position: .host, nickname: "나는 호스트", videoView: localVideoView)
-
             guard let hostIndex = items.firstIndex(where: { $0.position == .host }) else { return }
+            
+            let newItem = SectionItem(position: .host, nickname: "나는 호스트", videoView: localVideoView)
+
             items.remove(at: hostIndex)
             items.insert(newItem, at: hostIndex)
             
+            snapshot.deleteItems(items)
             snapshot.appendItems(items, toSection: 0)
+
             self.participantsCollectionViewController.dataSource.apply(snapshot, animatingDifferences: true)
+
         }.store(in: &cancellables)
         
         output.remoteVideos.sink { [weak self] remoteVideoViews in
@@ -112,50 +116,16 @@ public final class WaitingRoomViewController: BaseViewController, ViewController
             
             var snapshot = self.participantsCollectionViewController.dataSource.snapshot()
             var items = snapshot.itemIdentifiers
-            
-            var newItem = SectionItem(position: .guest3, nickname: "나는 게스트", videoView: remoteVideoView)
-
             guard let guestIndex = items.firstIndex(where: { $0.position == .guest3 }) else { return }
+            
+            let newItem = SectionItem(position: .guest3, nickname: "나는 게스트", videoView: remoteVideoView)
+
             items.remove(at: guestIndex)
             items.insert(newItem, at: guestIndex)
             
+            snapshot.deleteItems(items)
             snapshot.appendItems(items, toSection: 0)
-            self.participantsCollectionViewController.dataSource.apply(snapshot, animatingDifferences: true)
-        }.store(in: &cancellables)
-        
-        output.shouldShowToast.sink { [weak self] message in
-            print(message)
-        }.store(in: &cancellables)
-        
-        output.localVideo.sink { [weak self] localVideoView in
-            guard let self else { return }
-            var snapshot = self.participantsCollectionViewController.dataSource.snapshot()
-            var items = snapshot.itemIdentifiers
-            
-            var newItem = SectionItem(position: .host, nickname: "나는 호스트", videoView: localVideoView)
 
-            guard let hostIndex = items.firstIndex(where: { $0.position == .host }) else { return }
-            items.remove(at: hostIndex)
-            items.insert(newItem, at: hostIndex)
-            
-            snapshot.appendItems(items, toSection: 0)
-            self.participantsCollectionViewController.dataSource.apply(snapshot, animatingDifferences: true)
-        }.store(in: &cancellables)
-        
-        output.remoteVideos.sink { [weak self] remoteVideoViews in
-            guard let self else { return }
-            guard let remoteVideoView = remoteVideoViews.first else { return }
-            
-            var snapshot = self.participantsCollectionViewController.dataSource.snapshot()
-            var items = snapshot.itemIdentifiers
-            
-            var newItem = SectionItem(position: .guest3, nickname: "나는 게스트", videoView: remoteVideoView)
-
-            guard let guestIndex = items.firstIndex(where: { $0.position == .guest3 }) else { return }
-            items.remove(at: guestIndex)
-            items.insert(newItem, at: guestIndex)
-            
-            snapshot.appendItems(items, toSection: 0)
             self.participantsCollectionViewController.dataSource.apply(snapshot, animatingDifferences: true)
         }.store(in: &cancellables)
         


### PR DESCRIPTION
## 🤔 배경
diffableDataSource를 업데이트하는 과정에서 동작에는 문제가 없지만 경고가 발생하고 있었습니다.

## 📃 작업 내역
- diffableDataSource snapshot 업데이트 로직 수정

## ✅ 리뷰 노트

이미 있는 identifier와 동일한 identifier를 가지는 item들을 append하려고 해서 발생하는 문제였고, snapshot에서 기존 item들을 delete하고 새로 append해주는 방식으로 수정했습니다.

### 기존 코드
```swift
var items = snapshot.itemIdentifiers
guard let guestIndex = items.firstIndex(where: { $0.position == .guest3 }) else { return }

var newItem = SectionItem(position: .guest3, nickname: "나는 게스트", videoView: remoteVideoView)

items.remove(at: guestIndex)
items.insert(newItem, at: guestIndex)

snapshot.appendItems(items, toSection: 0) // 문제가 되던 부분

self.participantsCollectionViewController.dataSource.apply(snapshot, animatingDifferences: true)
```

### 변경된 코드
```swift
var items = snapshot.itemIdentifiers
guard let guestIndex = items.firstIndex(where: { $0.position == .guest3 }) else { return }

var newItem = SectionItem(position: .guest3, nickname: "나는 게스트", videoView: remoteVideoView)

items.remove(at: guestIndex) // identifier 충돌 문제 해결을 위해 추가
items.insert(newItem, at: guestIndex)

snapshot.deleteItems(items)
snapshot.appendItems(items, toSection: 0)

self.participantsCollectionViewController.dataSource.apply(snapshot, animatingDifferences: true)
```

### 추가 개선점
reconfigureItem 메소드로 existing Item 을 효율적으로 업데이트할 수 있다는데 잘안되네요.. 이건 좀 더 찾아보고 최종적으로 reconfigureItem 을 사용하는 방향으로 리팩토링하면 좋을 것 같습니다!



## 🎨 스크린샷

### Before
<img width="757" alt="image" src="https://github.com/user-attachments/assets/02a6b76e-dde0-470e-8b45-f9655dabdd7a">

### After

<img width="796" alt="image" src="https://github.com/user-attachments/assets/b867f492-1adb-421d-b49e-4c62b393550b">
