### PR TITLE
[FEAT/#77] 스티커를 선택할 수 있는 기능을 구현합니다.

### DIFF
--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
@@ -68,6 +68,7 @@ final class EventManager {
         case .create: createEvent(by: event)
         case .delete: deleteEvent(by: event)
         case .update: updateEvent(to: event)
+        case .unlock: unlockEvent(to: event)
         }
         callEventPublisher.send(true)
     }
@@ -124,6 +125,24 @@ final class EventManager {
             // OldOwner가 nil이거나 Old,New Owner가 서로 같을 때
             stickerDictionary[event.entity.id] = event.entity
 
+            resultEventPublihser.send(currenntStickerList)
+        }
+    }
+    
+    private func unlockEvent(to event: EventEntity) {
+        guard isObejctDeleted[event.entity.id] == false,
+              let oldSticker = stickerDictionary[event.entity.id]
+        else {
+            // 이미 처리된 상황이기에 아무 처리를 하지 않아도 문제가 없음
+            debugPrint("A/B 경쟁 상황에서 이미 삭제된 객체의 언락을 요청함")
+            return
+        }
+        
+        if oldSticker.owner == event.entity.owner {
+            var newSticker = stickerDictionary[event.entity.id]
+            newSticker?.updateOwner(to: nil)
+            
+            stickerDictionary[event.entity.id] = newSticker
             resultEventPublihser.send(currenntStickerList)
         }
     }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
@@ -15,6 +15,8 @@ final class EventQueue {
     
     func popLast() -> EventEntity? {
         let popLast = queue.popLast()
+        if queue.isEmpty { popablePublisher.send(false) }
+        
         return popLast
     }
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/EventEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/EventEntity.swift
@@ -24,7 +24,7 @@ public struct EventEntity: Equatable, Codable {
 }
 
 public enum EventType: Codable {
-    case create, update, delete
+    case create, update, delete, unlock
 }
 
 extension EventEntity {

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/StickerEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/StickerEntity.swift
@@ -85,7 +85,7 @@ extension Array where Element == StickerEntity {
     }
 
     public func isOwned(id: UUID, owner: String) -> Bool {
-        guard let target = first(where: { $0.id == id}) else { return false }
+        guard let target = first(where: { $0.id == id }) else { return false }
         return target.owner == nil || target.owner == owner
     }
     

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/StickerEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/StickerEntity.swift
@@ -83,4 +83,30 @@ extension Array where Element == StickerEntity {
         encoder.dateEncodingStrategy = .iso8601
         return try encoder.encode(self)
     }
+
+    public func isOwned(id: UUID, owner: String) -> Bool {
+        guard let target = first(where: { $0.id == id}) else { return false }
+        return target.owner == nil || target.owner == owner
+    }
+    
+    public mutating func lockedSticker(by owner: String) -> StickerEntity? {
+        if let index = firstIndex(where: { $0.owner == owner }) {
+            return self[index]
+        }
+        return nil
+    }
+    
+    public mutating func unlock(by owner: String) {
+        if let index = firstIndex(where: { $0.owner == owner }) {
+            self[index].updateOwner(to: nil)
+        }
+    }
+
+    public mutating func lock(by id: UUID, owner: String) -> StickerEntity? {
+        if let index = firstIndex(where: { $0.id == id }) {
+            self[index].updateOwner(to: owner)
+            return self[index]
+        }
+        return nil
+    }
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/StickerEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/StickerEntity.swift
@@ -7,9 +7,6 @@ public struct StickerEntity: Equatable, Codable {
     
     public let id: UUID
     public let image: String
-    public let frame: CGRect
-    public let owner: String?
-    public let latestUpdated: Date
     public private(set) var frame: CGRect
     public private(set) var owner: String?
     public private(set) var latestUpdated: Date

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/StickerEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/StickerEntity.swift
@@ -10,6 +10,9 @@ public struct StickerEntity: Equatable, Codable {
     public let frame: CGRect
     public let owner: String?
     public let latestUpdated: Date
+    public private(set) var frame: CGRect
+    public private(set) var owner: String?
+    public private(set) var latestUpdated: Date
     
     enum CodingKeys: String, CodingKey {
         case id, image, frame, owner, latestUpdated
@@ -64,6 +67,16 @@ public struct StickerEntity: Equatable, Codable {
             "height": frame.size.height
         ]
         try container.encode(frameDict, forKey: .frame)
+    }
+    
+    public mutating func updateOwner(to owner: String?) {
+        self.owner = owner
+        self.latestUpdated = Date()
+    }
+    
+    public mutating func updateFrame(to frame: CGRect) {
+        self.frame = frame
+        self.latestUpdated = Date()
     }
 }
 

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/StickerEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/StickerEntity.swift
@@ -78,6 +78,10 @@ public struct StickerEntity: Equatable, Codable {
 }
 
 extension Array where Element == StickerEntity {
+    subscript(safe index: Index) -> Iterator.Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+    
     public func encode() throws -> Data {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -91,7 +95,7 @@ extension Array where Element == StickerEntity {
     
     public mutating func lockedSticker(by owner: String) -> StickerEntity? {
         if let index = firstIndex(where: { $0.owner == owner }) {
-            return self[index]
+            return self[safe: index]
         }
         return nil
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/CanvasScrollView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/CanvasScrollView.swift
@@ -28,6 +28,8 @@ final class CanvasScrollView: UIScrollView {
         bouncesZoom = true
         showsHorizontalScrollIndicator = false
         showsVerticalScrollIndicator = false
+
+        imageView.isUserInteractionEnabled = true
     }
     
     func updateFrameImage(to image: UIImage) {

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
@@ -157,9 +157,7 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
         registerSticker(for: sticker)
         
         let stickerView = StickerView(sticker: sticker)
-        stickerView.tapHandler { [weak self] stickerID in
-            self?.input.send(.stickerViewDidTap(stickerID))
-        }
+        stickerView.delegate = self
         
         canvasScrollView.imageView.addSubview(stickerView)
         stickerView.update(with: sticker)
@@ -200,5 +198,11 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
     private func registerSticker(for sticker: StickerEntity) {
         let newIndex = canvasScrollView.imageView.subviews.count
         stickerIdDictionary[sticker.id] = newIndex
+    }
+}
+
+extension EditPhotoRoomGuestViewController: StickerViewActionDelegate {
+    func stickerView(_ stickerView: StickerView, didTap id: UUID) {
+        input.send(.stickerViewDidTap(id))
     }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
@@ -178,7 +178,11 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
             } else {
                 print("DEBUG: ADD NEW STICKER By Host, \(sticker.id)")
             }
+        let stickerView = StickerView(sticker: sticker)
+        stickerView.tapHandler { [weak self] stickerID in
+            self?.input.send(.stickerViewDidTap(stickerID))
         }
+        
     }
     
     // MARK: 원래는 Data가 아니라 imageURL 및 Image의 MetaData가 와야함.

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
@@ -146,43 +146,25 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
         at index: Int,
         with sticker: StickerEntity
     ) {
-        guard
-            let stickerImageView = canvasScrollView.imageView.subviews[index]
-                as? UIImageView
+        guard let stickerImageView = canvasScrollView
+            .imageView
+            .subviews[index] as? StickerView
         else { return }
         
-        guard let url = URL(string: sticker.image) else { return }
-        Task {
-            guard let (data, _) = try? await URLSession.shared.data(from: url)
-            else { return }
-            stickerImageView.image = UIImage(data: data)
-            stickerImageView.frame = sticker.frame
-        }
+        stickerImageView.update(with: sticker)
     }
     
     private func addNewSticker(to sticker: StickerEntity, isLocal: Bool) {
         registerSticker(for: sticker)
         
-        guard let url = URL(string: sticker.image) else { return }
-        Task {
-            guard let (data, _) = try? await URLSession.shared.data(from: url)
-            else { return }
-            
-            let stickerImageView = UIImageView(frame: sticker.frame)
-            stickerImageView.image = await UIImage(data: data)?.byPreparingForDisplay()
-            canvasScrollView.imageView.addSubview(stickerImageView)
-
-            if isLocal {
-                print("DEBUG: ADD NEW STICKER By Local, \(sticker.id)")
-                input.send(.createSticker(sticker))
-            } else {
-                print("DEBUG: ADD NEW STICKER By Host, \(sticker.id)")
-            }
         let stickerView = StickerView(sticker: sticker)
         stickerView.tapHandler { [weak self] stickerID in
             self?.input.send(.stickerViewDidTap(stickerID))
         }
         
+        canvasScrollView.imageView.addSubview(stickerView)
+        stickerView.update(with: sticker)
+        input.send(.createSticker(sticker))
     }
     
     // MARK: 원래는 Data가 아니라 imageURL 및 Image의 MetaData가 와야함.

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
@@ -120,7 +120,6 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
     }
     
     private func tempOffer() {
-        print("DEBUG: OFFER")
         offerUseCase.execute()
     }
     
@@ -167,7 +166,6 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
         input.send(.createSticker(sticker))
     }
     
-    // MARK: 원래는 Data가 아니라 imageURL 및 Image의 MetaData가 와야함.
     private func createStickerObject(by entity: EmojiEntity) {
         let imageSize: CGFloat = 64
         let frame = calculateCenterPosition(imageSize: imageSize)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -23,6 +23,7 @@ public final class EditPhotoRoomGuestViewModel {
     private let sendStickerToRepositoryUseCase: SendStickerToRepositoryUseCase
     
     private var emojiList: [EmojiEntity] = [] // MARK: 추후 삭제 예정
+    private let owner = "GUEST" + UUID().uuidString.prefix(4) // MARK: 임시 값(추후 ConnectionClient에서 받아옴)
     
     private let stickerObjectListSubject = CurrentValueSubject<[StickerEntity], Never>([])
     

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -67,7 +67,7 @@ public final class EditPhotoRoomGuestViewModel {
                 self?.sendEmoji()
             case .createSticker(let sticker):
                 self?.appendSticker(with: sticker)
-                self?.sendToRepository(with: sticker)
+                self?.sendToRepository(type: .create, with: sticker)
             case .frameButtonDidTap:
                 self?.toggleFrameImage()
             case .stickerViewDidTap(let stickerID):
@@ -112,8 +112,8 @@ public final class EditPhotoRoomGuestViewModel {
         output.send(.emojiEntity(entity: emojiList.randomElement()!))
     }
     
-    private func sendToRepository(with sticker: StickerEntity) {
-        sendStickerToRepositoryUseCase.execute(type: .create, sticker: sticker)
+    private func sendToRepository(type: EventType, with sticker: StickerEntity) {
+        sendStickerToRepositoryUseCase.execute(type: type, sticker: sticker)
     }
     
     func setupFrame() {

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -53,8 +53,6 @@ public final class EditPhotoRoomGuestViewModel {
         
         receiveStickerListUseCase.execute()
             .sink { [weak self] receivedStickerList in
-                let currentStickerList = self?.stickerObjectListSubject.value ?? []
-                if currentStickerList == receivedStickerList { return }
                 self?.stickerObjectListSubject.send(receivedStickerList)
             }
             .store(in: &cancellables)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -79,19 +79,35 @@ public final class EditPhotoRoomGuestViewModel {
     }
     
     private func handleStickerViewDidTap(with stickerID: UUID) {
-        var stickerList = stickerObjectListSubject.value
-        
         // MARK: 선택할 수 있는 객체인지 확인함
-        guard stickerList.isOwned(id: stickerID, owner: owner) else { return }
+        guard canInteractWithSticker(id: stickerID) else { return }
         
         // MARK: 필요시 이전 스티커를 unlock하고 반영함
+        unlockPreviousSticker()
+        
+        // MARK: Tap한 스티커를 lock하고 반영한다.
+        lockTappedSticker(id: stickerID)
+    }
+    
+    private func canInteractWithSticker(id: UUID) -> Bool {
+        let stickerList = stickerObjectListSubject.value
+        
+        return stickerList.isOwned(id: id, owner: owner)
+    }
+    
+    private func unlockPreviousSticker() {
+        var stickerList = stickerObjectListSubject.value
+        
         if let previousSticker = stickerList.lockedSticker(by: owner) {
             stickerList.unlock(by: owner)
             sendToRepository(type: .unlock, with: previousSticker)
         }
+    }
+    
+    private func lockTappedSticker(id: UUID) {
+        var stickerList = stickerObjectListSubject.value
         
-        // MARK: Tap한 스티커를 lock하고 반영한다.
-        if let tappedSticker = stickerList.lock(by: stickerID, owner: owner) {
+        if let tappedSticker = stickerList.lock(by: id, owner: owner) {
             stickerObjectListSubject.send(stickerList)
             sendToRepository(type: .update, with: tappedSticker)
         }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -78,6 +78,25 @@ public final class EditPhotoRoomGuestViewModel {
         return output.eraseToAnyPublisher()
     }
     
+    private func handleStickerViewDidTap(with stickerID: UUID) {
+        var stickerList = stickerObjectListSubject.value
+        
+        // MARK: 선택할 수 있는 객체인지 확인함
+        guard stickerList.isOwned(id: stickerID, owner: owner) else { return }
+        
+        // MARK: 필요시 이전 스티커를 unlock하고 반영함
+        if let previousSticker = stickerList.lockedSticker(by: owner) {
+            stickerList.unlock(by: owner)
+            sendToRepository(type: .unlock, with: previousSticker)
+        }
+        
+        // MARK: Tap한 스티커를 lock하고 반영한다.
+        if let tappedSticker = stickerList.lock(by: stickerID, owner: owner) {
+            stickerObjectListSubject.send(stickerList)
+            sendToRepository(type: .update, with: tappedSticker)
+        }
+    }
+    
     private func toggleFrameImage() {
         let currentFrameImageType = frameImageGenerator.frameType
         var newFrameImageType: FrameType

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -21,8 +21,9 @@ public final class EditPhotoRoomGuestViewModel {
     private let receiveStickerListUseCase: ReceiveStickerListUseCase
     private let sendStickerToRepositoryUseCase: SendStickerToRepositoryUseCase
     
-    private var emojiList: [EmojiEntity] = []
-    private var stickerObjectListSubject = CurrentValueSubject<[StickerEntity], Never>([])
+    private var emojiList: [EmojiEntity] = [] // MARK: 추후 삭제 예정
+    
+    private let stickerObjectListSubject = CurrentValueSubject<[StickerEntity], Never>([])
     
     private var cancellables = Set<AnyCancellable>()
     private var output = PassthroughSubject<Output, Never>()

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -8,6 +8,7 @@ public final class EditPhotoRoomGuestViewModel {
         case stickerButtonDidTap
         case frameButtonDidTap
         case createSticker(StickerEntity)
+        case stickerViewDidTap(UUID)
     }
     
     enum Output {
@@ -69,6 +70,8 @@ public final class EditPhotoRoomGuestViewModel {
                 self?.sendToRepository(with: sticker)
             case .frameButtonDidTap:
                 self?.toggleFrameImage()
+            case .stickerViewDidTap(let stickerID):
+                self?.handleStickerViewDidTap(with: stickerID)
             }
         }
         .store(in: &cancellables)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -184,9 +184,7 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
         registerSticker(for: sticker)
         
         let stickerView = StickerView(sticker: sticker)
-        stickerView.tapHandler { [weak self] stickerID in
-            self?.input.send(.stickerViewDidTap(stickerID))
-        }
+        stickerView.delegate = self
         
         canvasScrollView.imageView.addSubview(stickerView)
         stickerView.update(with: sticker)
@@ -227,5 +225,11 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
     private func registerSticker(for sticker: StickerEntity) {
         let newIndex = canvasScrollView.imageView.subviews.count
         stickerIdDictionary[sticker.id] = newIndex
+    }
+}
+
+extension EditPhotoRoomHostViewController: StickerViewActionDelegate {
+    func stickerView(_ stickerView: StickerView, didTap id: UUID) {
+        input.send(.stickerViewDidTap(id))
     }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -147,7 +147,6 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
     }
     
     private func tempOffer() {
-        print("DEBUG: OFFER")
         offerUseCase.execute()
     }
     
@@ -194,7 +193,6 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
         input.send(.createSticker(sticker))
     }
     
-    // MARK: 원래는 Data가 아니라 imageURL 및 Image의 MetaData가 와야함.
     private func createStickerObject(by entity: EmojiEntity) {
         let imageSize: CGFloat = 64
         let frame = calculateCenterPosition(imageSize: imageSize)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -173,43 +173,25 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
         at index: Int,
         with sticker: StickerEntity
     ) {
-        guard
-            let stickerImageView = canvasScrollView.imageView.subviews[index]
-                as? UIImageView
+        guard let stickerImageView = canvasScrollView
+            .imageView
+            .subviews[index] as? StickerView
         else { return }
         
-        guard let url = URL(string: sticker.image) else { return }
-        Task {
-            guard let (data, _) = try? await URLSession.shared.data(from: url)
-            else { return }
-            stickerImageView.image = UIImage(data: data)
-            stickerImageView.frame = sticker.frame
-        }
+        stickerImageView.update(with: sticker)
     }
     
     private func addNewSticker(to sticker: StickerEntity, isLocal: Bool) {
         registerSticker(for: sticker)
         
-        guard let url = URL(string: sticker.image) else { return }
-        Task {
-            guard let (data, _) = try? await URLSession.shared.data(from: url)
-            else { return }
-            
-            let stickerImageView = UIImageView(frame: sticker.frame)
-            stickerImageView.image = await UIImage(data: data)?.byPreparingForDisplay()
-            canvasScrollView.imageView.addSubview(stickerImageView)
-
-            if isLocal {
-                print("DEBUG: ADD NEW STICKER By Local, \(sticker.id)")
-                input.send(.createSticker(sticker))
-            } else {
-                print("DEBUG: ADD NEW STICKER By Server, \(sticker.id)")
-            }
         let stickerView = StickerView(sticker: sticker)
         stickerView.tapHandler { [weak self] stickerID in
             self?.input.send(.stickerViewDidTap(stickerID))
         }
         
+        canvasScrollView.imageView.addSubview(stickerView)
+        stickerView.update(with: sticker)
+        input.send(.createSticker(sticker))
     }
     
     // MARK: 원래는 Data가 아니라 imageURL 및 Image의 MetaData가 와야함.

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -205,7 +205,11 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
             } else {
                 print("DEBUG: ADD NEW STICKER By Server, \(sticker.id)")
             }
+        let stickerView = StickerView(sticker: sticker)
+        stickerView.tapHandler { [weak self] stickerID in
+            self?.input.send(.stickerViewDidTap(stickerID))
         }
+        
     }
     
     // MARK: 원래는 Data가 아니라 imageURL 및 Image의 MetaData가 와야함.

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -74,7 +74,7 @@ public final class EditPhotoRoomHostViewModel {
                 self?.sendEmoji()
             case .createSticker(let sticker):
                 self?.appendSticker(with: sticker)
-                self?.sendToRepository(with: sticker)
+                self?.sendToRepository(type: .create, with: sticker)
             case .frameButtonDidTap:
                 self?.toggleFrameImage()
             case .stickerViewDidTap(let stickerID):
@@ -119,8 +119,8 @@ public final class EditPhotoRoomHostViewModel {
         output.send(.emojiEntity(entity: emojiList.randomElement()!))
     }
     
-    private func sendToRepository(with sticker: StickerEntity) {
-        sendStickerToRepositoryUseCase.execute(type: .create, sticker: sticker)
+    private func sendToRepository(type: EventType, with sticker: StickerEntity) {
+        sendStickerToRepositoryUseCase.execute(type: type, sticker: sticker)
     }
     
     func setupFrame() {

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -86,19 +86,35 @@ public final class EditPhotoRoomHostViewModel {
     }
     
     private func handleStickerViewDidTap(with stickerID: UUID) {
-        var stickerList = stickerObjectListSubject.value
-        
         // MARK: 선택할 수 있는 객체인지 확인함
-        guard stickerList.isOwned(id: stickerID, owner: owner) else { return }
+        guard canInteractWithSticker(id: stickerID) else { return }
         
         // MARK: 필요시 이전 스티커를 unlock하고 반영함
+        unlockPreviousSticker()
+        
+        // MARK: Tap한 스티커를 lock하고 반영한다.
+        lockTappedSticker(id: stickerID)
+    }
+    
+    private func canInteractWithSticker(id: UUID) -> Bool {
+        let stickerList = stickerObjectListSubject.value
+        
+        return stickerList.isOwned(id: id, owner: owner)
+    }
+    
+    private func unlockPreviousSticker() {
+        var stickerList = stickerObjectListSubject.value
+        
         if let previousSticker = stickerList.lockedSticker(by: owner) {
             stickerList.unlock(by: owner)
             sendToRepository(type: .unlock, with: previousSticker)
         }
+    }
+    
+    private func lockTappedSticker(id: UUID) {
+        var stickerList = stickerObjectListSubject.value
         
-        // MARK: Tap한 스티커를 lock하고 반영한다.
-        if let tappedSticker = stickerList.lock(by: stickerID, owner: owner) {
+        if let tappedSticker = stickerList.lock(by: id, owner: owner) {
             stickerObjectListSubject.send(stickerList)
             sendToRepository(type: .update, with: tappedSticker)
         }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -60,8 +60,6 @@ public final class EditPhotoRoomHostViewModel {
         
         receiveStickerListUseCase.execute()
             .sink { [weak self] receivedStickerList in
-                let currentStickerList = self?.stickerObjectListSubject.value ?? []
-                if currentStickerList == receivedStickerList { return }
                 self?.stickerObjectListSubject.send(receivedStickerList)
             }
             .store(in: &cancellables)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -23,6 +23,7 @@ public final class EditPhotoRoomHostViewModel {
     private let sendStickerToRepositoryUseCase: SendStickerToRepositoryUseCase
     
     private var emojiList: [EmojiEntity] = [] // MARK: 추후 삭제 예정
+    private let owner = "Host" + UUID().uuidString.prefix(4) // MARK: 임시 값(추후 ConnectionClient에서 받아옴)
     
     private let stickerObjectListSubject = CurrentValueSubject<[StickerEntity], Never>([])
     

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -43,13 +43,6 @@ public final class EditPhotoRoomHostViewModel {
         bind()
     }
     
-    // Local -> [A]
-    // ViewModel -> [] XX
-    // Server -> [A, B, C]
-    // Local -> [A, B, C]
-    // Create -> Q
-    
-    
     private func bind() {
         fetchEmojiList()
         

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -8,6 +8,7 @@ public final class EditPhotoRoomHostViewModel {
         case stickerButtonDidTap
         case frameButtonDidTap
         case createSticker(StickerEntity)
+        case stickerViewDidTap(UUID)
     }
     
     enum Output {
@@ -76,6 +77,8 @@ public final class EditPhotoRoomHostViewModel {
                 self?.sendToRepository(with: sticker)
             case .frameButtonDidTap:
                 self?.toggleFrameImage()
+            case .stickerViewDidTap(let stickerID):
+                self?.handleStickerViewDidTap(with: stickerID)
             }
         }
         .store(in: &cancellables)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -21,8 +21,9 @@ public final class EditPhotoRoomHostViewModel {
     private let receiveStickerListUseCase: ReceiveStickerListUseCase
     private let sendStickerToRepositoryUseCase: SendStickerToRepositoryUseCase
     
-    private var emojiList: [EmojiEntity] = []
-    private var stickerObjectListSubject = CurrentValueSubject<[StickerEntity], Never>([])
+    private var emojiList: [EmojiEntity] = [] // MARK: 추후 삭제 예정
+    
+    private let stickerObjectListSubject = CurrentValueSubject<[StickerEntity], Never>([])
     
     private var cancellables = Set<AnyCancellable>()
     private var output = PassthroughSubject<Output, Never>()

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -85,6 +85,25 @@ public final class EditPhotoRoomHostViewModel {
         return output.eraseToAnyPublisher()
     }
     
+    private func handleStickerViewDidTap(with stickerID: UUID) {
+        var stickerList = stickerObjectListSubject.value
+        
+        // MARK: 선택할 수 있는 객체인지 확인함
+        guard stickerList.isOwned(id: stickerID, owner: owner) else { return }
+        
+        // MARK: 필요시 이전 스티커를 unlock하고 반영함
+        if let previousSticker = stickerList.lockedSticker(by: owner) {
+            stickerList.unlock(by: owner)
+            sendToRepository(type: .unlock, with: previousSticker)
+        }
+        
+        // MARK: Tap한 스티커를 lock하고 반영한다.
+        if let tappedSticker = stickerList.lock(by: stickerID, owner: owner) {
+            stickerObjectListSubject.send(stickerList)
+            sendToRepository(type: .update, with: tappedSticker)
+        }
+    }
+    
     private func toggleFrameImage() {
         let currentFrameImageType = frameImageGenerator.frameType
         var newFrameImageType: FrameType

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
@@ -1,12 +1,15 @@
+import Combine
 import DesignSystem
 import PhotoGetherDomainInterface
 import UIKit
 
 final class StickerView: UIImageView {
+    private let tapPublisher = PassthroughSubject<Void, Never>()
     private let nicknameLabel = UILabel()
 
     private var sticker: StickerEntity
 
+    private var cancellables = Set<AnyCancellable>()
 
     init(sticker: StickerEntity) {
         self.sticker = sticker
@@ -58,4 +61,17 @@ final class StickerView: UIImageView {
             
             self?.image = UIImage(data: data)
         }
+    }
+    
+    @objc private func handleTap() {
+        tapPublisher.send(())
+    }
+    
+    func tapHandler(_ completion: @escaping (UUID) -> Void) {
+        tapPublisher
+            .sink { [weak self] _ in
+                guard let self else { return }
+                completion(sticker.id)
+            }
+            .store(in: &cancellables)
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
@@ -1,16 +1,18 @@
-import Combine
 import DesignSystem
 import PhotoGetherDomainInterface
 import UIKit
 
+protocol StickerViewActionDelegate: AnyObject {
+    func stickerView(_ stickerView: StickerView, didTap id: UUID)
+}
+
 final class StickerView: UIImageView {
-    private let tapPublisher = PassthroughSubject<Void, Never>()
     private let nicknameLabel = UILabel()
 
     private var sticker: StickerEntity
 
-    private var cancellables = Set<AnyCancellable>()
-
+    weak var delegate: StickerViewActionDelegate?
+    
     init(sticker: StickerEntity) {
         self.sticker = sticker
         super.init(frame: sticker.frame)
@@ -84,16 +86,7 @@ final class StickerView: UIImageView {
     }
     
     @objc private func handleTap() {
-        tapPublisher.send(())
-    }
-    
-    func tapHandler(_ completion: @escaping (UUID) -> Void) {
-        tapPublisher
-            .sink { [weak self] _ in
-                guard let self else { return }
-                completion(sticker.id)
-            }
-            .store(in: &cancellables)
+        delegate?.stickerView(self, didTap: sticker.id)
     }
     
     func update(with sticker: StickerEntity) {

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
@@ -1,0 +1,61 @@
+import DesignSystem
+import PhotoGetherDomainInterface
+import UIKit
+
+final class StickerView: UIImageView {
+    private let nicknameLabel = UILabel()
+
+    private var sticker: StickerEntity
+
+
+    init(sticker: StickerEntity) {
+        self.sticker = sticker
+        super.init(frame: sticker.frame)
+        setupTapGesture()
+        addViews()
+        setupConstraints()
+        configureUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func addViews() {
+        addSubview(nicknameLabel)
+    }
+    
+    private func setupConstraints() {
+        nicknameLabel.snp.makeConstraints {
+            $0.top.equalTo(snp.bottom)
+            $0.trailing.equalTo(snp.trailing)
+        }
+    }
+    
+    private func configureUI() {
+        layer.borderColor = PTGColor.primaryGreen.color.cgColor
+        setImage(to: sticker.image)
+        
+        sticker.owner != nil
+        ? (layer.borderWidth = 1)
+        : (layer.borderWidth = 0)
+    }
+
+    private func setupTapGesture() {
+        isUserInteractionEnabled = true
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        addGestureRecognizer(tapGesture)
+    }
+    
+    private func setImage(to urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        
+        Task { [weak self] in
+            guard let (data, _) = try? await URLSession.shared.data(from: url)
+            else { return }
+            
+            self?.image = UIImage(data: data)
+        }
+    }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
@@ -52,6 +52,26 @@ final class StickerView: UIImageView {
         addGestureRecognizer(tapGesture)
     }
     
+    private func updateFrame(to frame: CGRect) {
+        guard sticker.frame != frame else { return }
+        
+        sticker.updateFrame(to: frame)
+        self.frame = frame
+    }
+    
+    private func updateOwner(to owner: String?) {
+        guard sticker.owner != owner else { return }
+        
+        sticker.updateOwner(to: owner)
+        if let owner = owner {
+            nicknameLabel.text = owner
+            layer.borderWidth = 1
+        } else {
+            nicknameLabel.text = nil
+            layer.borderWidth = 0
+        }
+    }
+    
     private func setImage(to urlString: String) {
         guard let url = URL(string: urlString) else { return }
         
@@ -75,3 +95,9 @@ final class StickerView: UIImageView {
             }
             .store(in: &cancellables)
     }
+    
+    func update(with sticker: StickerEntity) {
+        updateOwner(to: sticker.owner)
+        updateFrame(to: sticker.frame)
+    }
+}


### PR DESCRIPTION
## 커밋단위로 리뷰하는게 가장 편하십니다.
- 작업이 복잡하여 잘 분리하여 커밋해두었습니다.

## 🤔 배경
- 스티커뷰에 닉네임을 표시하거나 `owner`를 표기하기 위해 `커스텀 UIImageView`가 필요했습니다.
- 해당 스티커뷰는 탭 이벤트를 제공해야했습니다.
- `EventHub`를 거쳐 `Host`, `Guest`간 통신에 문제가 없었어야 했습니다.

## 📃 작업 내역
- `StickerView` 구현: `StickerView` `UI` 와 `tapPublisher`를 통한 탭 이벤트 처리 구현
- `StickerView` 업데이트 최적화: `StickerEntity` 상태 비교를 통해 불필요한 업데이트 방지
- 스티커 선택 비즈니스 로직 구현: `StickerView`의 `tap`시 `unlock/lock` 및 `EventHub` 반영 처리.
- `StickerEntity` 배열 확장: `owner` 확인, `unlock/lock` 로직 재사용을 위한 유틸리티 메서드 추가
- `Host/Guest` 구분 기능 추가: 임시적으로 사용자 역할을 구분합니다.
  - `private let owner = "GUEST" + UUID().uuidString.prefix(4)`
  - 임시로 `UUID`를 이용해 각 `Guest`들의 `owner`를 유니크하게 구분할 수 있습니다.

## ✅ 리뷰 노트
### StickerView에서 tap관련 cancellable 관리
```swift
// StickerView.swift
    func tapHandler(_ completion: @escaping (UUID) -> Void) {
        tapPublisher
            .sink { [weak self] _ in
                guard let self else { return }
                completion(sticker.id)
            }
            .store(in: &cancellables)
    }

// EditPhotoRoomViewController.swift
    private func addNewSticker(to sticker: StickerEntity, isLocal: Bool) {
        registerSticker(for: sticker)
        
        let stickerView = StickerView(sticker: sticker)
        stickerView.tapHandler { [weak self] stickerID in
            self?.input.send(.stickerViewDidTap(stickerID))
        }
        
        canvasScrollView.imageView.addSubview(stickerView)
        stickerView.update(with: sticker)
        input.send(.createSticker(sticker))
    }
```
**가장 큰 이유는 `StickerView`가 자주 생성되고 삭제된다는 점에 있었습니다.**

> 스티커는 동적으로 생성/삭제 되므로 `ViewController`가 개별 스티커의 이벤트 구독을 관리하기에 불편했습니다.
>
> 스티커가 삭제될 때 구독을 해제해야 하며, 이를 `ViewController`에서 수동으로 추적하여 처리하기에는 오버헤드가 크다고 판단했습니다.
>
> 따라서 `tapHandler(_:)` 탈출 클로저를 제공하여 구독은 `StickerView` 내부에서 관리하고, StickerView가 삭제되면 내부적으로 
>
> `cancellable`이 해제되어 메모리 누수를 방지하고자 이 방식을 채택했습니다.

### 같은 값일 때 불필요한 할당 방지
```swift
    private func updateFrame(to frame: CGRect) {
        guard sticker.frame != frame else { return }
        
        sticker.updateFrame(to: frame)
        self.frame = frame
    }
    
    private func updateOwner(to owner: String?) {
        guard sticker.owner != owner else { return }
        
        sticker.updateOwner(to: owner)
        if let owner = owner {
            nicknameLabel.text = owner
            layer.borderWidth = 1
        } else {
            nicknameLabel.text = nil
            layer.borderWidth = 0
        }
    }
```
- 같은 값을 재할당하는 것으로 불필요한 오버헤드를 발생시킬 수 있을 것 같아 변경여부를 확인한 뒤 할당하였습니다.
- `StickerView`또한 `ViewModel`을 두어 `removeDuplicate()`를 통해 관리할 수도 있었지만, 
1. 추가적인 ViewModel 구현을 지양하고 struct를 고수하고자
2. 추가적인 StickerEntity를 관리하는 DataSource를 두는 것을 지양하고자
이 방식을 택하였습니다.

### SitckerView 탭 이벤트 처리 비즈니스 로직 구현
```swift
    private func handleStickerViewDidTap(with stickerID: UUID) {
        // MARK: 선택할 수 있는 객체인지 확인함
        guard canInteractWithSticker(id: stickerID) else { return }
        
        // MARK: 필요시 이전 스티커를 unlock하고 반영함
        unlockPreviousSticker()
        
        // MARK: Tap한 스티커를 lock하고 반영한다.
        lockTappedSticker(id: stickerID)
    }
```
> 선택 가능한 객체 확인 (canInteractWithSticker)
- StickerView 탭 이벤트 발생 시, 해당 스티커가 선택 가능한 상태인지(소유 여부 확인) 판단하는 로직 추가.
- stickerList.isOwned 메서드 활용으로 코드를 간결하게 구성했습니다.

> 이전 선택된 스티커 해제 (unlockPreviousSticker)
- 기존에 선택된 스티커를 해제하고, EventHub에 해제 상태를 반영하도록 처리.
- 스티커 해제는 lockedSticker와 unlock 메서드를 활용해 구현.

> 현재 선택된 스티커 잠금 (lockTappedSticker)
- 선택된 스티커를 잠금 상태로 설정하고, EventHub에 업데이트 요청.
- stickerList.lock 메서드를 사용해 간결하게 구현.

> 상태 관리 최적화
- stickerObjectListSubject.value를 활용해 상태를 읽고 업데이트하며, 변경 시 필요한 부분만 EventHub와 동기화.

## 🎨 스크린샷
![dd](https://github.com/user-attachments/assets/dbc407b6-c406-4a77-ac36-2aca4a9bcfcf)
- 탭한 이벤트가 전파됩니다.
- 소유하지 못한 객체는 비즈니스 로직에서 이벤트를 전파하지 못하도록 걸러집니다.

## 🚀 테스트 방법
1. EditPhotoRoomFeatureDemo에서 Host, Guest로 두 개의 디바이스로 런
2. *임시*: [프레임] 버튼을 눌러 커넥션 연결
3. 스티커 버튼을 생성하고 tap을 통해 테스트가 가능합니다.
