### PR TITLE
[FEAT/#96] Offer 관련 개발환경 개선

### DIFF
--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature.xcodeproj/project.pbxproj
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		050F6E132CEE19A2002F5473 /* PhotoGetherData.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 050F6E112CEE19A2002F5473 /* PhotoGetherData.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		053DC8532CE32AE900DC9F35 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 053DC8522CE32AE900DC9F35 /* DesignSystem.framework */; };
 		053DC8542CE32AE900DC9F35 /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 053DC8522CE32AE900DC9F35 /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		05B1F2C32CF43CFE001C1E83 /* BaseFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B59514D2CDB5FFC00B89C85 /* BaseFeature.framework */; };
+		05B1F2C42CF43CFE001C1E83 /* BaseFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B59514D2CDB5FFC00B89C85 /* BaseFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		05DBEF502CEEF86C0075329B /* PhotoGetherDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05DBEF4F2CEEF86C0075329B /* PhotoGetherDomain.framework */; };
 		05DBEF512CEEF86C0075329B /* PhotoGetherDomain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 05DBEF4F2CEEF86C0075329B /* PhotoGetherDomain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		05DBEF532CEEF8720075329B /* PhotoGetherDomainInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05DBEF522CEEF8720075329B /* PhotoGetherDomainInterface.framework */; };
@@ -58,6 +60,7 @@
 				05DBEF572CEEF8870075329B /* PhotoGetherDomainTesting.framework in Embed Frameworks */,
 				05DBEF542CEEF8720075329B /* PhotoGetherDomainInterface.framework in Embed Frameworks */,
 				60CB82A92CDB522900873DD6 /* EditPhotoRoomFeature.framework in Embed Frameworks */,
+				05B1F2C42CF43CFE001C1E83 /* BaseFeature.framework in Embed Frameworks */,
 				603CFC1A2CEF40D500AEFB2C /* PhotoGetherNetwork.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -143,6 +146,7 @@
 				7B59510C2CDB598600B89C85 /* FeatureTesting.framework in Frameworks */,
 				60A64BBF2CEF7B520097D4F3 /* WebRTC in Frameworks */,
 				05DBEF562CEEF8870075329B /* PhotoGetherDomainTesting.framework in Frameworks */,
+				05B1F2C32CF43CFE001C1E83 /* BaseFeature.framework in Frameworks */,
 				05DBEF532CEEF8720075329B /* PhotoGetherDomainInterface.framework in Frameworks */,
 				60CB82A82CDB522900873DD6 /* EditPhotoRoomFeature.framework in Frameworks */,
 				603CFC192CEF40D500AEFB2C /* PhotoGetherNetwork.framework in Frameworks */,

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
@@ -14,16 +14,10 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
     private let viewModel: EditPhotoRoomGuestViewModel
     private var stickerIdDictionary: [UUID: Int] = [:]
     
-    // MARK: 개발 끝나면 지워야됨
-    private let offerUseCase: SendOfferUseCase
-    private var isConnected = false
-    
     public init(
-        viewModel: EditPhotoRoomGuestViewModel,
-        offerUseCase: SendOfferUseCase
+        viewModel: EditPhotoRoomGuestViewModel
     ) {
         self.viewModel = viewModel
-        self.offerUseCase = offerUseCase
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -119,15 +113,8 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
         viewModel.setupFrame()
     }
     
-    private func tempOffer() {
-        offerUseCase.execute()
-    }
-    
     private func updateFrameImage(to image: UIImage) {
-        // MARK: 임시 클라연결
-        if isConnected { tempOffer() }
-        else { canvasScrollView.updateFrameImage(to: image) }
-        isConnected = true
+        canvasScrollView.updateFrameImage(to: image)
     }
     
     /// DataSource를 기반으로 이미 존재하는 스티커를 업데이트하거나 새로운 스티커를 추가합니다.

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -14,16 +14,10 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
     private let viewModel: EditPhotoRoomHostViewModel
     private var stickerIdDictionary: [UUID: Int] = [:]
     
-    // MARK: 개발 끝나면 지워야됨
-    private let offerUseCase: SendOfferUseCase
-    private var isConnected = false
-    
     public init(
-        viewModel: EditPhotoRoomHostViewModel,
-        offerUseCase: SendOfferUseCase
+        viewModel: EditPhotoRoomHostViewModel
     ) {
         self.viewModel = viewModel
-        self.offerUseCase = offerUseCase
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -145,16 +139,9 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
         
         viewModel.setupFrame()
     }
-    
-    private func tempOffer() {
-        offerUseCase.execute()
-    }
-    
+
     private func updateFrameImage(to image: UIImage) {
-        // MARK: 임시 클라연결
-        if isConnected { tempOffer() }
-        else { canvasScrollView.updateFrameImage(to: image) }
-        isConnected = true
+        canvasScrollView.updateFrameImage(to: image)
     }
     
     /// DataSource를 기반으로 이미 존재하는 스티커를 업데이트하거나 새로운 스티커를 추가합니다.

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
@@ -98,7 +98,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             viewModel: editPhotoRoomGuestViewModel,
             offerUseCase: offerUseCase
         )
-        window?.rootViewController = editPhotoRoomHostViewController
+        
+        let offerViewController = OfferTempViewController(
+            sendOfferUseCase: offerUseCase,
+            hostViewController: editPhotoRoomHostViewController,
+            guestViewController: editPhotoRoomGuestViewController
+        )
+        let navigationController = UINavigationController(rootViewController: offerViewController)
+        
+        window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
@@ -83,8 +83,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             sendStickerToRepositoryUseCase: sendStickerToRepositoryHostUseCase
         )
         let editPhotoRoomHostViewController = EditPhotoRoomHostViewController(
-            viewModel: editPhotoRoomHostViewModel,
-            offerUseCase: offerUseCase
+            viewModel: editPhotoRoomHostViewModel
         )
         
         let editPhotoRoomGuestViewModel = EditPhotoRoomGuestViewModel(
@@ -95,8 +94,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
         
         let editPhotoRoomGuestViewController = EditPhotoRoomGuestViewController(
-            viewModel: editPhotoRoomGuestViewModel,
-            offerUseCase: offerUseCase
+            viewModel: editPhotoRoomGuestViewModel
         )
         
         let offerViewController = OfferTempViewController(

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/Source/OfferTempViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/Source/OfferTempViewController.swift
@@ -1,0 +1,99 @@
+import UIKit
+import DesignSystem
+import Combine
+import BaseFeature
+import PhotoGetherDomainInterface
+import EditPhotoRoomFeature
+
+final class OfferTempViewController: BaseViewController, ViewControllerConfigure {
+    private let stackView = UIStackView()
+    private let hostButton = UIButton()
+    private let guestButton = UIButton()
+    private let offerButton = UIButton()
+    
+    private let sendOfferUseCase: SendOfferUseCase
+    private let hostViewController: EditPhotoRoomHostViewController
+    private let guestViewController: EditPhotoRoomGuestViewController
+    
+    init(
+        sendOfferUseCase: SendOfferUseCase,
+        hostViewController: EditPhotoRoomHostViewController,
+        guestViewController: EditPhotoRoomGuestViewController
+    ) {
+        self.sendOfferUseCase = sendOfferUseCase
+        self.hostViewController = hostViewController
+        self.guestViewController = guestViewController
+        super.init(nibName: nil, bundle: nil)
+        
+        addViews()
+        setupConstraints()
+        configureUI()
+        bindOutput()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func addViews() {
+        view.addSubview(stackView)
+        [hostButton, guestButton, offerButton]
+            .forEach { stackView.addArrangedSubview($0) }
+    }
+    
+    func setupConstraints() {
+        stackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalTo(200)
+            $0.height.equalTo(272)
+        }
+        
+        [hostButton, guestButton, offerButton].forEach {
+            $0.snp.makeConstraints {
+                $0.width.equalTo(200)
+                $0.height.equalTo(80)
+            }
+        }
+    }
+    
+    func configureUI() {
+        view.backgroundColor = .white
+        
+        stackView.axis = .vertical
+        stackView.spacing = 16
+        stackView.distribution = .equalSpacing
+        
+        [hostButton, guestButton, offerButton].forEach {
+            $0.setTitleColor(PTGColor.gray90.color, for: .normal)
+            $0.backgroundColor = PTGColor.gray50.color
+        }
+        
+        hostButton.setTitle("HOST", for: .normal)
+        guestButton.setTitle("GUEST", for: .normal)
+        offerButton.setTitle("SEND OFFER", for: .normal)
+    }
+    
+    func bindOutput() {
+        hostButton.tapPublisher
+            .sink { [weak self] in
+                guard let self else { return }
+                navigationController?.pushViewController(hostViewController, animated: true)
+            }
+            .store(in: &cancellables)
+        
+        guestButton.tapPublisher
+            .sink { [weak self] in
+                guard let self else { return }
+                self.navigationController?.pushViewController(guestViewController, animated: true)
+            }
+            .store(in: &cancellables)
+        
+        offerButton.tapPublisher
+            .sink { [weak self] in
+                guard let self else { return }
+                sendOfferUseCase.execute()
+            }
+            .store(in: &cancellables)
+    }
+}


### PR DESCRIPTION
## 🤔 배경
EditPhotoFeatureDemo 개발 시 Guest와 Host의 커넥션연결을 위해 필요 없는 의존성을 가지고 있었습니다.
이를 분리하고자 DemoApp에서만 사용하는 SendOffer 를 요청하는 임시 뷰가 필요했습니다.

## 📃 작업 내역
- 임시 뷰 `SendOfferTempViewController` 구현
- `EditPhotoRoomFeature`의 `ViewController`에서 필요없는 `SendOfferUseCase` 제거

## ✅ 리뷰 노트
개발 환경 개선을 위한 작업이며 Debug에서만 활용하여 실제 release될 부분이 아니기 때문에 특별히 리뷰하실 부분은 없습니다.

- EditPhotoFeatureDemo를 Run하면 SendOffer를 요청할 수 있습니다.
- SceneDelegate에서 rootViewController를 Host/Guest로 나누어 실행할 때의 불편함을 개선하였습니다.

## 🎨 스크린샷
<img width="372" alt="image" src="https://github.com/user-attachments/assets/2c7fe37a-efd1-4fb9-be09-dc223586b3a6">


## 🚀 테스트 방법
EditPhotoFeatureDemoApp을 실행하면 됩니다.
