### PR TITLE
[FEAT/#95] 서버 방 생성 작업을 진행합니다.

### DIFF
--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionClientImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionClientImpl.swift
@@ -10,12 +10,14 @@ public final class ConnectionClientImpl: ConnectionClient {
     public var receivedDataPublisher = PassthroughSubject<Data, Never>()
     
     public var remoteVideoView: UIView = CapturableVideoView()
-    public var localVideoView: UIView = CapturableVideoView()
     
     public var peerID: String = ""
     public var roomID: String = ""
     
-    public init(signalingService: SignalingService, webRTCService: WebRTCService) {
+    public init(
+        signalingService: SignalingService,
+        webRTCService: WebRTCService
+    ) {
         self.signalingService = signalingService
         self.webRTCService = webRTCService
         
@@ -27,7 +29,6 @@ public final class ConnectionClientImpl: ConnectionClient {
         
         // VideoTrack과 나와 상대방의 화면을 볼 수 있는 뷰를 바인딩합니다.
         self.bindRemoteVideo()
-        self.bindLocalVideo()
     }
     
     public func sendOffer() {
@@ -40,17 +41,8 @@ public final class ConnectionClientImpl: ConnectionClient {
         self.webRTCService.sendData(data)
     }
     
-    public func captureVideos() -> [UIImage] {
-        let localCaptureImage = getCapturedVideos(isLocal: true)
-        let remoteCaptureImage = getCapturedVideos(isLocal: false)
-        
-        return [localCaptureImage, remoteCaptureImage]
-    }
-    
-    private func getCapturedVideos(isLocal: Bool) -> UIImage {
-        let targetVideo = isLocal ? self.localVideoView : self.remoteVideoView
-        
-        guard let videoView = targetVideo as? CapturableVideoView else {
+    public func captureVideo() -> UIImage {
+        guard let videoView = self.remoteVideoView as? CapturableVideoView else {
             return UIImage()
         }
         
@@ -71,7 +63,7 @@ public final class ConnectionClientImpl: ConnectionClient {
         self.webRTCService.renderRemoteVideo(to: remoteVideoView)
     }
     
-    private func bindLocalVideo() {
+    public func bindLocalVideo(_ localVideoView: UIView) {
         guard let localVideoView = localVideoView as? RTCMTLVideoView else { return }
         self.webRTCService.startCaptureLocalVideo(renderer: localVideoView)
     }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
@@ -4,7 +4,17 @@ import PhotoGetherDomainInterface
 public final class ConnectionRepositoryImpl: ConnectionRepository {
     public var clients: [ConnectionClient]
     
-    public init(clients: [ConnectionClient]) {
+    private let localVideoView = CapturableVideoView()
+    
+    private let roomService: RoomService
+    
+    public init(clients: [ConnectionClient], roomService: RoomService) {
         self.clients = clients
+        self.roomService = roomService
+        bindLocalVideo()
+    }
+    
+    private func bindLocalVideo() {
+        self.clients.forEach { $0.bindLocalVideo(localVideoView) }
     }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
@@ -8,7 +8,7 @@ public final class ConnectionRepositoryImpl: ConnectionRepository {
     private let _localVideoView = CapturableVideoView()
     
     public var localVideoView: UIView { _localVideoView }
-    public var CapturedLocalVideo: UIImage? { _localVideoView.capturedImage }
+    public var capturedLocalVideo: UIImage? { _localVideoView.capturedImage }
     
     public let roomService: RoomService
     

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
@@ -1,7 +1,6 @@
 import UIKit
 import PhotoGetherDomainInterface
 
-
 public final class ConnectionRepositoryImpl: ConnectionRepository {
     public var clients: [ConnectionClient]
     

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
@@ -1,12 +1,16 @@
-import Foundation
+import UIKit
 import PhotoGetherDomainInterface
+
 
 public final class ConnectionRepositoryImpl: ConnectionRepository {
     public var clients: [ConnectionClient]
     
-    private let localVideoView = CapturableVideoView()
+    private let _localVideoView = CapturableVideoView()
     
-    private let roomService: RoomService
+    public var localVideoView: UIView { _localVideoView }
+    public var CapturedLocalVideo: UIImage? { _localVideoView.capturedImage }
+    
+    public let roomService: RoomService
     
     public init(clients: [ConnectionClient], roomService: RoomService) {
         self.clients = clients
@@ -15,6 +19,6 @@ public final class ConnectionRepositoryImpl: ConnectionRepository {
     }
     
     private func bindLocalVideo() {
-        self.clients.forEach { $0.bindLocalVideo(localVideoView) }
+        self.clients.forEach { $0.bindLocalVideo(_localVideoView) }
     }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Extension/Data+toDTO.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Extension/Data+toDTO.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension Data {
-    func toDTO(type: Decodable.Type) -> Decodable? {
+    func toDTO<T: Decodable>(type: T.Type) -> T? {
         return try? JSONDecoder().decode(type, from: self)
     }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Extension/Data+toDTO.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Extension/Data+toDTO.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension Data {
-    func toDTO<T: Decodable>(type: T.Type) -> T? {
-        return try? JSONDecoder().decode(type, from: self)
+    func toDTO<T: Decodable>(type: T.Type, decoder: JSONDecoder) -> T? {
+        return try? decoder.decode(type, from: self)
     }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Extension/Encodable+toData.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Extension/Encodable+toData.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Encodable {
+    func toData(encoder: JSONEncoder) -> Data? {
+        return try? encoder.encode(self)
+    }
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/DTO/ResponseDTO/CreateRoomResponseDTO.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/DTO/ResponseDTO/CreateRoomResponseDTO.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-struct CreateRoomResponseDTO: Decodable {
-    let roomID: String
-    let userID: String
-}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/DTO/ResponseDTO/CreateRoomResponseDTO.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/DTO/ResponseDTO/CreateRoomResponseDTO.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct CreateRoomResponseDTO: Decodable {
+    let roomID: String
+    let userID: String
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Delegate/RoomServiceDelegate.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Delegate/RoomServiceDelegate.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PhotoGetherDomainInterface
 
 public protocol RoomServiceDelegate: AnyObject {
     func roomService(_ roomService: RoomService, didReceiveResponseCreateRoom response: String)

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/CreateRoomMessage.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/CreateRoomMessage.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-struct CreateRoomMessage: Decodable {
-    let roomID: String
-    let userID: String
-}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/CreateRoomResponseMessage.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/CreateRoomResponseMessage.swift
@@ -1,0 +1,11 @@
+import Foundation
+import PhotoGetherDomainInterface
+
+public struct CreateRoomResponseMessage: Decodable {
+    let roomID: String
+    let userID: String
+    
+    public func toEntity() -> RoomOwnerEntity {
+        RoomOwnerEntity(roomID: self.roomID, userID: self.userID)
+    }
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/CreateRoomResponseMessage.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/CreateRoomResponseMessage.swift
@@ -3,9 +3,9 @@ import PhotoGetherDomainInterface
 
 public struct CreateRoomResponseMessage: Decodable {
     let roomID: String
-    let userID: String
+    let hostID: String
     
     public func toEntity() -> RoomOwnerEntity {
-        RoomOwnerEntity(roomID: self.roomID, userID: self.userID)
+        RoomOwnerEntity(roomID: self.roomID, hostID: self.hostID)
     }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/JoinRoomRequestMessage.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/JoinRoomRequestMessage.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public struct JoinRoomRequestMessage: Encodable {
+    public let roomID: String
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/JoinRoomResponseMessage.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/JoinRoomResponseMessage.swift
@@ -1,0 +1,16 @@
+import Foundation
+import PhotoGetherDomainInterface
+
+public struct JoinRoomResponseMessage: Decodable {
+    public let userID: String
+    public let clientsID: [String]
+    
+    public init(userID: String, clientsID: [String]) {
+        self.userID = userID
+        self.clientsID = clientsID
+    }
+    
+    public func toEntity() -> JoinRoomEntity {
+        JoinRoomEntity(userID: self.userID, clientsID: self.clientsID)
+    }
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Service/RoomService.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Service/RoomService.swift
@@ -1,7 +1,0 @@
-import Foundation
-import WebRTC
-import PhotoGetherNetwork
-
-public protocol RoomService {
-    func send(request: any WebSocketRequestable)
-}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
@@ -4,10 +4,10 @@ import PhotoGetherNetwork
 import PhotoGetherDomainInterface
 
 public final class RoomServiceImpl: RoomService {
-    public var createRoomResponsePublisher: AnyPublisher<CreateRoomEntity, Error> {
+    public var createRoomResponsePublisher: AnyPublisher<RoomOwnerEntity, Error> {
         _createRoomResponsePublisher.eraseToAnyPublisher()
     }
-    private let _createRoomResponsePublisher = PassthroughSubject<CreateRoomEntity, Error>()
+    private let _createRoomResponsePublisher = PassthroughSubject<RoomOwnerEntity, Error>()
     private var cancellables: Set<AnyCancellable> = []
     
     private let decoder = JSONDecoder()
@@ -19,7 +19,7 @@ public final class RoomServiceImpl: RoomService {
         bindWebSocketClient()
     }
     
-    public func createRoom() -> AnyPublisher<CreateRoomEntity, Error> {
+    public func createRoom() -> AnyPublisher<RoomOwnerEntity, Error> {
         let createRoomRequest = RoomRequestDTO(messageType: .createRoom)
         
         guard let data = createRoomRequest.toData(encoder: encoder) else {
@@ -47,7 +47,7 @@ public final class RoomServiceImpl: RoomService {
                         debugPrint("Decode Failed to CreateRoomMessage: \(message)")
                         return
                     }
-                    let createRoomEntity = CreateRoomEntity(roomID: message.roomID, userID: message.userID)
+                    let createRoomEntity = RoomOwnerEntity(roomID: message.roomID, userID: message.userID)
                     _createRoomResponsePublisher.send(createRoomEntity)
                     
                     debugPrint("방 생성 성공: \(message.roomID) \n 유저 아이디: \(message.userID)")

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
@@ -53,12 +53,15 @@ public final class RoomServiceImpl: RoomService {
             .sink { [weak self] data in
                 guard let self else { return }
                 
-                guard let response = data.toDTO(type: RoomResponseDTO.self) else { return }
+                guard let response = data.toDTO(type: RoomResponseDTO.self, decoder: decoder) else { return }
                 
                 switch response.messageType {
                 case .createRoom:
                     guard let message = response.message else { return }
-                    guard let message = message.toDTO(type: CreateRoomResponseMessage.self) else {
+                    guard let message = message.toDTO(
+                        type: CreateRoomResponseMessage.self,
+                        decoder: decoder
+                    ) else {
                         debugPrint("Decode Failed to CreateRoomMessage: \(message)")
                         return
                     }
@@ -84,7 +87,7 @@ public final class RoomServiceImpl: RoomService {
     
     private func decodeMessage<T: Decodable>(_ message: Data?, type: T.Type) -> T? {
         guard let message = message else { return nil }
-        guard let dto = message.toDTO(type: type) else {
+        guard let dto = message.toDTO(type: type, decoder: decoder) else {
             debugPrint("Decode Failed to: \(message)")
             return nil
         }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
@@ -68,7 +68,7 @@ public final class RoomServiceImpl: RoomService {
                     let roomOwnerEntity = message.toEntity()
                     _createRoomResponsePublisher.send(roomOwnerEntity)
                     
-                    debugPrint("방 생성 성공: \(message.roomID) \n 유저 아이디: \(message.userID)")
+                    debugPrint("방 생성 성공: \(message.roomID) \n 유저 아이디: \(message.hostID)")
                 case .joinRoom:
                     guard let message = decodeMessage(
                         response.message,

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
@@ -28,5 +28,19 @@ extension RoomServiceImpl: WebSocketClientDelegate {
     
     public func webSocket(_ webSocket: WebSocketClient, didReceiveData data: Data) {
         // TODO: 생성된 방번호 고유 아이디가 담긴 정보 디코딩
+        // data Response DTO -> 한번 디코딩하고 타입 확인
+        guard let response = data.toDTO(type: RoomResponseDTO.self) else { return }
+        
+        switch response.messageType {
+        case .createRoom:
+            guard let message = response.message else { return }
+            guard let message = message.toDTO(type: CreateRoomMessage.self) else {
+                debugPrint("Decode Failed to CreateRoomMessage: \(message)")
+                return
+            }
+            debugPrint("방 생성 성공: \(message.roomID) \n 유저 아이디: \(message.userID)")
+        case .joinRoom:
+            break
+        }
     }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
@@ -9,6 +9,7 @@ public final class RoomServiceImpl: RoomService {
     
     public init(webSocketClient: WebSocketClient) {
         self.webSocketClient = webSocketClient
+        self.webSocketClient.delegates.append(self)
     }
     
     public func createRoom() -> Bool {

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PhotoGetherNetwork
+import PhotoGetherDomainInterface
 
 public final class RoomServiceImpl: RoomService {
     private let decoder = JSONDecoder()
@@ -10,8 +11,9 @@ public final class RoomServiceImpl: RoomService {
         self.webSocketClient = webSocketClient
     }
     
-    public func send(request: any WebSocketRequestable) {
-        guard let data = request.toData(encoder: encoder) else {
+    public func send(request: Encodable) {
+        guard let request = request as? (any WebSocketRequestable),
+                let data = request.toData(encoder: encoder) else {
             debugPrint("방 생성 요청 데이터 인코딩 실패: \(request)")
             return
         }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
@@ -7,7 +7,11 @@ public final class RoomServiceImpl: RoomService {
     public var createRoomResponsePublisher: AnyPublisher<RoomOwnerEntity, Error> {
         _createRoomResponsePublisher.eraseToAnyPublisher()
     }
+    public var joinRoomResponsePublisher: AnyPublisher<JoinRoomEntity, Error> {
+        _joinRoomResponsePublisher.eraseToAnyPublisher()
+    }
     private let _createRoomResponsePublisher = PassthroughSubject<RoomOwnerEntity, Error>()
+    private let _joinRoomResponsePublisher = PassthroughSubject<JoinRoomEntity, Error>()
     private var cancellables: Set<AnyCancellable> = []
     
     private let decoder = JSONDecoder()
@@ -31,7 +35,18 @@ public final class RoomServiceImpl: RoomService {
         return createRoomResponsePublisher
     }
     
-    public func joinRoom() { }
+    public func joinRoom(to roomID: String) -> AnyPublisher<JoinRoomEntity, Error> {
+        let joinRoomMessage = JoinRoomRequestMessage(roomID: roomID).toData(encoder: encoder)
+        let joinRoomRequest = RoomRequestDTO(messageType: .joinRoom, message: joinRoomMessage)
+        
+        guard let data = joinRoomRequest.toData(encoder: encoder) else {
+            debugPrint("방 참가 요청 데이터 인코딩 실패: \(joinRoomRequest)")
+            return Fail(error: RoomServiceError.failedToEncoding).eraseToAnyPublisher()
+        }
+        
+        webSocketClient.send(data: data)
+        return joinRoomResponsePublisher
+    }
     
     private func bindWebSocketClient() {
         self.webSocketClient.webSocketdidReceiveDataPublisher
@@ -43,18 +58,38 @@ public final class RoomServiceImpl: RoomService {
                 switch response.messageType {
                 case .createRoom:
                     guard let message = response.message else { return }
-                    guard let message = message.toDTO(type: CreateRoomMessage.self) else {
+                    guard let message = message.toDTO(type: CreateRoomResponseMessage.self) else {
                         debugPrint("Decode Failed to CreateRoomMessage: \(message)")
                         return
                     }
-                    let createRoomEntity = RoomOwnerEntity(roomID: message.roomID, userID: message.userID)
-                    _createRoomResponsePublisher.send(createRoomEntity)
+                    let roomOwnerEntity = message.toEntity()
+                    _createRoomResponsePublisher.send(roomOwnerEntity)
                     
                     debugPrint("방 생성 성공: \(message.roomID) \n 유저 아이디: \(message.userID)")
                 case .joinRoom:
-                    break
+                    guard let message = decodeMessage(
+                        response.message,
+                        type: JoinRoomResponseMessage.self
+                    ) else {
+                        debugPrint("Decode Failed to JoinRoomEntity: \(String(describing: response.message))")
+                        return
+                    }
+                    let joinRoomEntity = message.toEntity()
+                    _joinRoomResponsePublisher.send(joinRoomEntity)
+                    
+                    debugPrint("방 참가 성공\n 유저 아이디: \(message.userID) \n 방 유저들 아이디: \(message.clientsID)")
                 }
             }.store(in: &cancellables)
+    }
+    
+    private func decodeMessage<T: Decodable>(_ message: Data?, type: T.Type) -> T? {
+        guard let message = message else { return nil }
+        guard let dto = message.toDTO(type: type) else {
+            debugPrint("Decode Failed to: \(message)")
+            return nil
+        }
+        
+        return dto
     }
 }
 

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/RoomServiceImpl.swift
@@ -11,15 +11,20 @@ public final class RoomServiceImpl: RoomService {
         self.webSocketClient = webSocketClient
     }
     
-    public func send(request: Encodable) {
-        guard let request = request as? (any WebSocketRequestable),
-                let data = request.toData(encoder: encoder) else {
-            debugPrint("방 생성 요청 데이터 인코딩 실패: \(request)")
-            return
+    public func createRoom() -> Bool {
+        let createRoomRequest = RoomRequestDTO(messageType: .createRoom)
+        
+        guard let data = createRoomRequest.toData(encoder: encoder) else {
+            debugPrint("방 생성 요청 데이터 인코딩 실패: \(createRoomRequest)")
+            return false
         }
         
         webSocketClient.send(data: data)
+        
+        return true
     }
+    
+    public func joinRoom() { }
 }
 
 // MARK: WebSocketDelegate

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/SignalingServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/SignalingServiceImpl.swift
@@ -10,7 +10,7 @@ final public class SignalingServiceImpl: SignalingService {
     
     public init(webSocketClient: WebSocketClient) {
         self.webSocketClient = webSocketClient
-        self.webSocketClient.delegate = self
+        self.webSocketClient.delegates.append(self) 
     }
     
     public func connect() {

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/WebRTCServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/WebRTCServiceImpl.swift
@@ -134,12 +134,22 @@ public extension WebRTCServiceImpl {
             fps: Int(fps.maxFrameRate)
         )
         
+        flipVideoRenderer(renderer)
+        
         self.localVideoTrack?.add(renderer)
     }
     
     /// remoteVideoTrack에서 수신된 모든 프레임을 렌더링할 렌더러를 등록합니다.
     func renderRemoteVideo(to renderer: RTCVideoRenderer) {
+        flipVideoRenderer(renderer)
+        
         self.remoteVideoTrack?.add(renderer)
+    }
+    
+    /// 들어오는 화면에 좌우 반전을 적용합니다
+    private func flipVideoRenderer(_ renderer: RTCVideoRenderer) {
+        guard let renderedView = renderer as? UIView else { return }
+        renderedView.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
     }
     
     private func configureAudioSession() {

--- a/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketClient.swift
+++ b/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketClient.swift
@@ -1,7 +1,11 @@
 import Foundation
+import Combine
 
 public protocol WebSocketClient {
     var delegates: [WebSocketClientDelegate] { get set }
+    var webSocketDidConnectPublisher: AnyPublisher<Void, Never> { get }
+    var webSocketDidDisconnectPublisher: AnyPublisher<Void, Never> { get }
+    var webSocketdidReceiveDataPublisher: AnyPublisher<Data, Never> { get }
     
     func connect()
     func send(data: Data)

--- a/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketClient.swift
+++ b/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public protocol WebSocketClient {
-    var delegate: WebSocketClientDelegate? { get set }
+    var delegates: [WebSocketClientDelegate] { get set }
     
     func connect()
     func send(data: Data)

--- a/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketClientDelegate.swift
+++ b/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketClientDelegate.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(*, deprecated, message: "Publisher로 교체될 예정입니다.")
 public protocol WebSocketClientDelegate: AnyObject {
     func webSocketDidConnect(_ webSocket: WebSocketClient)
     func webSocketDidDisconnect(_ webSocket: WebSocketClient)

--- a/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketClientImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketClientImpl.swift
@@ -1,8 +1,25 @@
 import Foundation
 import PhotoGetherDomainInterface
+import Combine
 
 public final class WebSocketClientImpl: NSObject, WebSocketClient {
+    @available(*, deprecated, message: "Publisher로 교체될 예정입니다.")
     public var delegates: [WebSocketClientDelegate] = []
+    
+    private let _webSocketDidConnectPublisher = PassthroughSubject<Void, Never>()
+    private let _webSocketDidDisconnectPublisher = PassthroughSubject<Void, Never>()
+    private let _webSocketdidReceiveDataPublisher = PassthroughSubject<Data, Never>()
+    
+    public var webSocketDidConnectPublisher: AnyPublisher<Void, Never> {
+        _webSocketDidConnectPublisher.eraseToAnyPublisher()
+    }
+    public var webSocketDidDisconnectPublisher: AnyPublisher<Void, Never> {
+        _webSocketDidDisconnectPublisher.eraseToAnyPublisher()
+    }
+    public var webSocketdidReceiveDataPublisher: AnyPublisher<Data, Never> {
+        _webSocketdidReceiveDataPublisher.eraseToAnyPublisher()
+    }
+    
     private let url: URL
     private var socket: URLSessionWebSocketTask?
     
@@ -28,6 +45,7 @@ public final class WebSocketClientImpl: NSObject, WebSocketClient {
             
             switch message {
             case .success(.data(let data)):
+                self._webSocketdidReceiveDataPublisher.send(data)
                 self.delegates.forEach{
                     $0.webSocket(self, didReceiveData: data)
                 }
@@ -46,6 +64,7 @@ public final class WebSocketClientImpl: NSObject, WebSocketClient {
     private func disconnect() {
         self.socket?.cancel()
         self.socket = nil
+        self._webSocketDidDisconnectPublisher.send(())
         self.delegates.forEach {
             $0.webSocketDidDisconnect(self)
         }
@@ -58,6 +77,7 @@ extension WebSocketClientImpl: URLSessionWebSocketDelegate, URLSessionDelegate {
         webSocketTask: URLSessionWebSocketTask,
         didOpenWithProtocol protocol: String?
     ) {
+        self._webSocketDidConnectPublisher.send(())
         self.delegates.forEach {
             $0.webSocketDidConnect(self)
         }

--- a/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketClientImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketClientImpl.swift
@@ -2,7 +2,7 @@ import Foundation
 import PhotoGetherDomainInterface
 
 public final class WebSocketClientImpl: NSObject, WebSocketClient {
-    public var delegate: WebSocketClientDelegate?
+    public var delegates: [WebSocketClientDelegate] = []
     private let url: URL
     private var socket: URLSessionWebSocketTask?
     
@@ -28,7 +28,9 @@ public final class WebSocketClientImpl: NSObject, WebSocketClient {
             
             switch message {
             case .success(.data(let data)):
-                self.delegate?.webSocket(self, didReceiveData: data)
+                self.delegates.forEach{
+                    $0.webSocket(self, didReceiveData: data)
+                }
                 self.readMessage()
                 
             case .success:
@@ -44,7 +46,9 @@ public final class WebSocketClientImpl: NSObject, WebSocketClient {
     private func disconnect() {
         self.socket?.cancel()
         self.socket = nil
-        self.delegate?.webSocketDidDisconnect(self)
+        self.delegates.forEach {
+            $0.webSocketDidDisconnect(self)
+        }
     }
 }
 
@@ -54,7 +58,9 @@ extension WebSocketClientImpl: URLSessionWebSocketDelegate, URLSessionDelegate {
         webSocketTask: URLSessionWebSocketTask,
         didOpenWithProtocol protocol: String?
     ) {
-        self.delegate?.webSocketDidConnect(self)
+        self.delegates.forEach {
+            $0.webSocketDidConnect(self)
+        }
     }
     
     public func urlSession(

--- a/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketRequestable.swift
+++ b/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/WebSocket/WebSocketRequestable.swift
@@ -4,12 +4,4 @@ public protocol WebSocketRequestable: Encodable {
     associatedtype RequestType: Encodable
     var messageType: RequestType { get }
     var message: Data? { get }
-    
-    func toData(encoder: JSONEncoder) -> Data?
-}
-
-public extension WebSocketRequestable {
-    func toData(encoder: JSONEncoder) -> Data? {
-        return try? encoder.encode(self)
-    }
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CaptureVideosUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CaptureVideosUseCaseImpl.swift
@@ -3,8 +3,8 @@ import PhotoGetherDomainInterface
 
 public final class CaptureVideosUseCaseImpl: CaptureVideosUseCase {
     public func execute() -> [UIImage] {
-        let localImage = [connectionRepository.clients[0].captureVideos()[0]]
-        let remoteImages = connectionRepository.clients.map { $0.captureVideos()[1] }
+        let localImage = [connectionRepository.capturedLocalVideo!]
+        let remoteImages = connectionRepository.clients.map { $0.captureVideo() }
         
         return localImage + remoteImages
     }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
@@ -1,0 +1,14 @@
+import Foundation
+import PhotoGetherDomainInterface
+
+public final class CreateRoomUseCaseImpl: CreateRoomUseCase {
+    public func execute() -> Result<(roomID: String, userID: String), Error> {
+        repository.
+    }
+    
+    private let repository: ConnectionRepository
+    
+    public init(repository: ConnectionRepository) {
+        self.repository = repository
+    }
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
@@ -2,8 +2,8 @@ import Foundation
 import PhotoGetherDomainInterface
 
 public final class CreateRoomUseCaseImpl: CreateRoomUseCase {
-    public func execute() -> Result<(roomID: String, userID: String), Error> {
-        repository.
+    public func execute() -> Bool {
+        repository.roomService.createRoom()
     }
     
     private let repository: ConnectionRepository

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
@@ -2,13 +2,14 @@ import Foundation
 import PhotoGetherDomainInterface
 
 public final class CreateRoomUseCaseImpl: CreateRoomUseCase {
+    @discardableResult
     public func execute() -> Bool {
-        repository.roomService.createRoom()
+        connectionRepository.roomService.createRoom()
     }
     
-    private let repository: ConnectionRepository
+    private let connectionRepository: ConnectionRepository
     
-    public init(repository: ConnectionRepository) {
-        self.repository = repository
+    public init(connectionRepository: ConnectionRepository) {
+        self.connectionRepository = connectionRepository
     }
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
@@ -1,9 +1,9 @@
 import Foundation
+import Combine
 import PhotoGetherDomainInterface
 
 public final class CreateRoomUseCaseImpl: CreateRoomUseCase {
-    @discardableResult
-    public func execute() -> Bool {
+    public func execute() -> AnyPublisher<CreateRoomEntity, any Error> {
         connectionRepository.roomService.createRoom()
     }
     

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
@@ -7,7 +7,11 @@ public final class CreateRoomUseCaseImpl: CreateRoomUseCase {
     
     public func execute() -> AnyPublisher<String, any Error> {
         connectionRepository.roomService.createRoom()
-            .map { self.inviteMessage + "photoGether://createRoom?roomID=\($0.roomID)&hostID=\($0.userID)" }
+            .map { [weak self] in
+                let message = self?.inviteMessage ?? ""
+                let scheme = "photoGether://createRoom?roomID=\($0.roomID)&hostID=\($0.hostID)"
+                return message + scheme
+            }
             .eraseToAnyPublisher()
     }
     

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CreateRoomUseCaseImpl.swift
@@ -3,8 +3,12 @@ import Combine
 import PhotoGetherDomainInterface
 
 public final class CreateRoomUseCaseImpl: CreateRoomUseCase {
-    public func execute() -> AnyPublisher<CreateRoomEntity, any Error> {
+    private let inviteMessage = "PhotoGether 앱에서 초대를 보냈습니다.\n같이 사진 찍어요! 📷\n"
+    
+    public func execute() -> AnyPublisher<String, any Error> {
         connectionRepository.roomService.createRoom()
+            .map { self.inviteMessage + "photoGether://createRoom?roomID=\($0.roomID)&hostID=\($0.userID)" }
+            .eraseToAnyPublisher()
     }
     
     private let connectionRepository: ConnectionRepository

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/GetLocalVideoUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/GetLocalVideoUseCaseImpl.swift
@@ -5,7 +5,7 @@ import PhotoGetherDomainInterface
 public final class GetLocalVideoUseCaseImpl: GetLocalVideoUseCase {
     public func execute() -> UIView {
         // TODO: 리포지토리에서 하나의 localVideoView만 들고 있도록 변경 예정
-        connectionRepository.clients[0].localVideoView
+        connectionRepository.localVideoView
     }
     
     private let connectionRepository: ConnectionRepository

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/JoinRoomUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/JoinRoomUseCaseImpl.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Combine
+import PhotoGetherDomainInterface
+
+public final class JoinRoomUseCaseImpl: JoinRoomUseCase {
+    // TODO: 수정 필요
+    public func execute() -> AnyPublisher<Bool, Never> {
+        return Just(true)
+            .delay(for: .seconds(3), scheduler: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+    
+    private let connectionRepository: ConnectionRepository
+    
+    public init(connectionRepository: ConnectionRepository) {
+        self.connectionRepository = connectionRepository
+    }
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/ConnectionClient.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/ConnectionClient.swift
@@ -4,11 +4,11 @@ import Combine
 
 public protocol ConnectionClient {
     var remoteVideoView: UIView { get }
-    var localVideoView: UIView { get }
     
     var receivedDataPublisher: PassthroughSubject<Data, Never> { get }
     
     func sendOffer()
     func sendData(data: Data)
-    func captureVideos() -> [UIImage]
+    func captureVideo() -> UIImage
+    func bindLocalVideo(_ localVideoView: UIView)
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/ConnectionClient.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/ConnectionClient.swift
@@ -4,7 +4,7 @@ import Combine
 
 public protocol ConnectionClient {
     var remoteVideoView: UIView { get }
-    
+    var userInfo: UserInfoEntity? { get }
     var receivedDataPublisher: PassthroughSubject<Data, Never> { get }
     
     func sendOffer()

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/CreateRoomEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/CreateRoomEntity.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct CreateRoomEntity {
+    public let roomID: String
+    public let userID: String
+    
+    public init(roomID: String, userID: String) {
+        self.roomID = roomID
+        self.userID = userID
+    }
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/JoinRoomEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/JoinRoomEntity.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct JoinRoomEntity {
+    public let userID: String
+    public let clientsID: [String]
+    
+    public init(userID: String, clientsID: [String]) {
+        self.userID = userID
+        self.clientsID = clientsID
+    }
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/RoomOwnerEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/RoomOwnerEntity.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct CreateRoomEntity {
+public struct RoomOwnerEntity {
     public let roomID: String
     public let userID: String
     

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/RoomOwnerEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/RoomOwnerEntity.swift
@@ -2,10 +2,10 @@ import Foundation
 
 public struct RoomOwnerEntity {
     public let roomID: String
-    public let userID: String
+    public let hostID: String
     
-    public init(roomID: String, userID: String) {
+    public init(roomID: String, hostID: String) {
         self.roomID = roomID
-        self.userID = userID
+        self.hostID = hostID
     }
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/UserInfoEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/UserInfoEntity.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public struct UserInfoEntity: Identifiable {
+    public var id: String
+    public var nickname: String
+    public var isHost: Bool
+    public var viewPosition: ViewPosition
+    public var roomID: String?
+    
+    public enum ViewPosition: Int {
+        case topLeading
+        case topTrailing
+        case bottomLeading
+        case bottomTrailing
+    }
+    
+    public init(
+        id: String,
+        nickname: String,
+        isHost: Bool,
+        viewPosition: ViewPosition,
+        roomID: String? = nil
+    ) {
+        self.id = id
+        self.nickname = nickname
+        self.isHost = isHost
+        self.viewPosition = viewPosition
+        self.roomID = roomID
+    }
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/ConnectionRepository.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/ConnectionRepository.swift
@@ -4,5 +4,5 @@ public protocol ConnectionRepository {
     var clients: [ConnectionClient] { get }
     var roomService: RoomService { get }
     var localVideoView: UIView { get }
-    var CapturedLocalVideo: UIImage? { get }
+    var capturedLocalVideo: UIImage? { get }
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/ConnectionRepository.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/ConnectionRepository.swift
@@ -1,5 +1,8 @@
-import Foundation
+import UIKit
 
 public protocol ConnectionRepository {
     var clients: [ConnectionClient] { get }
+    var roomService: RoomService { get }
+    var localVideoView: UIView { get }
+    var CapturedLocalVideo: UIImage? { get }
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Service/RoomService.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Service/RoomService.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol RoomService {
+    func send(request: Encodable)
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Service/RoomService.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Service/RoomService.swift
@@ -2,8 +2,8 @@ import Foundation
 import Combine
 
 public protocol RoomService {
-    var createRoomResponsePublisher: AnyPublisher<CreateRoomEntity, Error> { get }
+    var createRoomResponsePublisher: AnyPublisher<RoomOwnerEntity, Error> { get }
     
-    func createRoom() -> AnyPublisher<CreateRoomEntity, Error>
+    func createRoom() -> AnyPublisher<RoomOwnerEntity, Error>
     func joinRoom()
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Service/RoomService.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Service/RoomService.swift
@@ -1,6 +1,9 @@
 import Foundation
+import Combine
 
 public protocol RoomService {
-    func createRoom() -> Bool
+    var createRoomResponsePublisher: AnyPublisher<CreateRoomEntity, Error> { get }
+    
+    func createRoom() -> AnyPublisher<CreateRoomEntity, Error>
     func joinRoom()
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Service/RoomService.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Service/RoomService.swift
@@ -1,5 +1,6 @@
 import Foundation
 
 public protocol RoomService {
-    func send(request: Encodable)
+    func createRoom() -> Bool
+    func joinRoom()
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Service/RoomService.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Service/RoomService.swift
@@ -5,5 +5,5 @@ public protocol RoomService {
     var createRoomResponsePublisher: AnyPublisher<RoomOwnerEntity, Error> { get }
     
     func createRoom() -> AnyPublisher<RoomOwnerEntity, Error>
-    func joinRoom()
+    func joinRoom(to roomID: String) -> AnyPublisher<JoinRoomEntity, Error>
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/CreateRoomUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/CreateRoomUseCase.swift
@@ -1,6 +1,6 @@
 import Foundation
+import Combine
 
 public protocol CreateRoomUseCase {
-    @discardableResult
-    func execute() -> Bool
+    func execute() -> AnyPublisher<CreateRoomEntity, any Error>
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/CreateRoomUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/CreateRoomUseCase.swift
@@ -2,5 +2,5 @@ import Foundation
 import Combine
 
 public protocol CreateRoomUseCase {
-    func execute() -> AnyPublisher<CreateRoomEntity, any Error>
+    func execute() -> AnyPublisher<String, any Error>
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/CreateRoomUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/CreateRoomUseCase.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol CreateRoomUseCase {
+    func execute() -> Result<(roomID: String, userID: String), Error>
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/CreateRoomUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/CreateRoomUseCase.swift
@@ -1,5 +1,6 @@
 import Foundation
 
 public protocol CreateRoomUseCase {
+    @discardableResult
     func execute() -> Bool
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/CreateRoomUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/CreateRoomUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol CreateRoomUseCase {
-    func execute() -> Result<(roomID: String, userID: String), Error>
+    func execute() -> Bool
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/JoinRoomUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/JoinRoomUseCase.swift
@@ -1,0 +1,5 @@
+import Combine
+
+public protocol JoinRoomUseCase {
+    func execute() -> AnyPublisher<Bool, Never>
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainTesting/JoinRoomUseCaseMock.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainTesting/JoinRoomUseCaseMock.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Combine
+import PhotoGetherDomainInterface
+
+public final class JoinRoomUseCaseMock: JoinRoomUseCase {
+    public func execute() -> AnyPublisher<Bool, Never> {
+        return Just(true)
+            .delay(for: .seconds(3), scheduler: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+}

--- a/PhotoGether/PhotoGether/App/SceneDelegate.swift
+++ b/PhotoGether/PhotoGether/App/SceneDelegate.swift
@@ -97,13 +97,31 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             createRoomUseCase: createRoomUseCase
         )
         
-        let viewController: WaitingRoomViewController = WaitingRoomViewController(
+        let waitingRoomViewController: WaitingRoomViewController = WaitingRoomViewController(
             viewModel: viewModel,
             photoRoomViewController: photoRoomViewController
         )
         
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = UINavigationController(rootViewController: viewController)
+        
+        if !isHost {
+            let joinRoomUseCase: JoinRoomUseCase = JoinRoomUseCaseImpl(
+                connectionRepository: connectionRepository
+            )
+            
+            let enterLoadingViewModel = EnterLoadingViewModel(
+                joinRoomUseCase: joinRoomUseCase
+            )
+            let enterLoadingViewController = EnterLoadingViewController(
+                viewModel: enterLoadingViewModel,
+                waitingRoomViewController: waitingRoomViewController
+            )
+            
+            window?.rootViewController = UINavigationController(rootViewController: enterLoadingViewController)
+        } else {
+            window?.rootViewController = UINavigationController(rootViewController: waitingRoomViewController)
+        }
+        
         window?.makeKeyAndVisible()
     }
 }

--- a/PhotoGether/PhotoGether/App/SceneDelegate.swift
+++ b/PhotoGether/PhotoGether/App/SceneDelegate.swift
@@ -74,6 +74,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             connectionRepository: connectionRepository
         )
         
+        let createRoomUseCase: CreateRoomUseCase = CreateRoomUseCaseImpl(
+            connectionRepository: connectionRepository
+        )
+        
         let photoRoomViewModel: PhotoRoomViewModel = PhotoRoomViewModel(
             captureVideosUseCase: captureVideosUseCase
         )
@@ -87,7 +91,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let viewModel: WaitingRoomViewModel = WaitingRoomViewModel(
             sendOfferUseCase: sendOfferUseCase,
             getLocalVideoUseCase: getLocalVideoUseCase,
-            getRemoteVideoUseCase: getRemoteVideoUseCase
+            getRemoteVideoUseCase: getRemoteVideoUseCase,
+            createRoomUseCase: createRoomUseCase
         )
         
         let viewController: WaitingRoomViewController = WaitingRoomViewController(

--- a/PhotoGether/PhotoGether/App/SceneDelegate.swift
+++ b/PhotoGether/PhotoGether/App/SceneDelegate.swift
@@ -54,7 +54,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
         
         let connectionRepository: ConnectionRepository = ConnectionRepositoryImpl(
-            clients: [connectionClient]
+            clients: [connectionClient],
+            roomService: roomService
         )
         
         let sendOfferUseCase: SendOfferUseCase = SendOfferUseCaseImpl(

--- a/PhotoGether/PhotoGether/App/SceneDelegate.swift
+++ b/PhotoGether/PhotoGether/App/SceneDelegate.swift
@@ -22,10 +22,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         debugPrint("SignalingServer URL: \(url)")
         
         var isHost: Bool = true
+        var roomOwnerEntity: RoomOwnerEntity?
         
         if let urlContext = connectionOptions.urlContexts.first {
             // MARK: 딥링크로 들어온지 여부로 호스트 게스트 판단
             isHost = false
+            roomOwnerEntity = URLParser.parsingIDs(from: urlContext.url)
         }
         
         let webScoketClient: WebSocketClient = WebSocketClientImpl(url: url)

--- a/PhotoGether/PhotoGether/App/SceneDelegate.swift
+++ b/PhotoGether/PhotoGether/App/SceneDelegate.swift
@@ -27,7 +27,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if let urlContext = connectionOptions.urlContexts.first {
             // MARK: 딥링크로 들어온지 여부로 호스트 게스트 판단
             isHost = false
-            roomOwnerEntity = URLParser.parsingIDs(from: urlContext.url)
+            roomOwnerEntity = DeepLinkParser.parseRoomInfo(from: urlContext.url)
         }
         
         let webScoketClient: WebSocketClient = WebSocketClientImpl(url: url)

--- a/PhotoGether/PhotoGether/Source/DeepLinkParser.swift
+++ b/PhotoGether/PhotoGether/Source/DeepLinkParser.swift
@@ -1,8 +1,8 @@
 import Foundation
 import PhotoGetherDomainInterface
 
-public enum URLParser {
-    public static func parsingIDs(from url: URL) -> RoomOwnerEntity? {
+public enum DeepLinkParser {
+    public static func parseRoomInfo(from url: URL) -> RoomOwnerEntity? {
         guard let queryItems = parsingURLQueryItems(url) else { return nil }
         
         guard let roomID = queryItems.first(where: { $0.name == "roomID" })?.value,
@@ -10,7 +10,7 @@ public enum URLParser {
             return nil
         }
         
-        return RoomOwnerEntity(roomID: roomID, userID: hostID)
+        return RoomOwnerEntity(roomID: roomID, hostID: hostID)
     }
     
     private static func parsingURLQueryItems(_ url: URL) -> [URLQueryItem]? {

--- a/PhotoGether/PhotoGether/Source/URLParser.swift
+++ b/PhotoGether/PhotoGether/Source/URLParser.swift
@@ -1,12 +1,16 @@
 import Foundation
+import PhotoGetherDomainInterface
 
 public enum URLParser {
-    public static func parsingRoomID(from url: URL) -> String? {
+    public static func parsingIDs(from url: URL) -> RoomOwnerEntity? {
         guard let queryItems = parsingURLQueryItems(url) else { return nil }
         
-        let roomID = queryItems.first(where: { $0.name == "roomID" })?.value
+        guard let roomID = queryItems.first(where: { $0.name == "roomID" })?.value,
+              let hostID = queryItems.first(where: { $0.name == "userID" })?.value else {
+            return nil
+        }
         
-        return roomID
+        return RoomOwnerEntity(roomID: roomID, userID: hostID)
     }
     
     private static func parsingURLQueryItems(_ url: URL) -> [URLQueryItem]? {

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/View/WaitingRoomView.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/View/WaitingRoomView.swift
@@ -4,7 +4,7 @@ import DesignSystem
 final class WaitingRoomView: UIView {
     let bottomBarView = UIView()
     let micButton = PTGMicButton(micState: .on)
-    let shareButton = PTGCircleButton(type: .link)
+    let linkButton = PTGCircleButton(type: .link)
     let startButton = PTGPrimaryButton()
     
     init() {
@@ -32,7 +32,7 @@ final class WaitingRoomView: UIView {
 private extension WaitingRoomView {
     func addViews() {
         [bottomBarView, micButton].forEach { addSubview($0) }
-        [shareButton, startButton].forEach {
+        [linkButton, startButton].forEach {
             bottomBarView.addSubview($0)
         }
     }
@@ -45,7 +45,7 @@ private extension WaitingRoomView {
             $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
         }
         
-        shareButton.snp.makeConstraints {
+        linkButton.snp.makeConstraints {
             $0.size.equalTo(Constants.circleButtonSize)
             $0.leading.equalToSuperview()
             $0.centerY.equalToSuperview()
@@ -53,7 +53,7 @@ private extension WaitingRoomView {
         
         startButton.snp.makeConstraints {
             $0.height.equalTo(Constants.startButtonHeight)
-            $0.leading.equalTo(shareButton.snp.trailing)
+            $0.leading.equalTo(linkButton.snp.trailing)
                 .offset(Constants.bottomBarViewHorizontalInset)
             $0.trailing.equalToSuperview()
             $0.centerY.equalToSuperview()

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/EnterLoadingViewController.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/EnterLoadingViewController.swift
@@ -67,6 +67,7 @@ public final class EnterLoadingViewController: BaseViewController, ViewControlle
             guard let self else { return }
             switch $0 {
             case .navigateToWaitingRoom(let isGuest):
+                self.modalPresentationStyle = .fullScreen
                 self.present(waitingRoomViewController, animated: false)
             }
         }

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/EnterLoadingViewController.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/EnterLoadingViewController.swift
@@ -55,6 +55,7 @@ public final class EnterLoadingViewController: BaseViewController, ViewControlle
     public func configureUI() {
         view.backgroundColor = PTGColor.gray90.color
         label.text = "방에 입장 중입니다..."
+        label.textAlignment = .center
         label.font = .systemFont(ofSize: 20)
         label.textColor = .white
         label.setKern()

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/EnterLoadingViewController.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/EnterLoadingViewController.swift
@@ -1,0 +1,74 @@
+import UIKit
+import Combine
+import BaseFeature
+import DesignSystem
+import PhotoGetherDomainInterface
+
+public final class EnterLoadingViewController: BaseViewController, ViewControllerConfigure {
+    private let viewModel: EnterLoadingViewModel
+    private let waitingRoomViewController: WaitingRoomViewController
+    private let label = UILabel()
+    private let activityIndicator = UIActivityIndicatorView()
+    private let input = PassthroughSubject<EnterLoadingViewModel.Input, Never>()
+    
+    public init(
+        viewModel: EnterLoadingViewModel,
+        waitingRoomViewController: WaitingRoomViewController
+    ) {
+        self.viewModel = viewModel
+        self.waitingRoomViewController = waitingRoomViewController
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        addViews()
+        setupConstraints()
+        configureUI()
+        bindOutput()
+        activityIndicator.startAnimating()
+        input.send(.viewDidLoad)
+    }
+    
+    public func addViews() {
+        view.addSubview(label)
+        view.addSubview(activityIndicator)
+    }
+    
+    public func setupConstraints() {
+        activityIndicator.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.height.equalTo(100)
+        }
+        label.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(activityIndicator.snp.bottom).offset(10)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+    }
+    
+    public func configureUI() {
+        view.backgroundColor = PTGColor.gray90.color
+        label.text = "방에 입장 중입니다..."
+        label.font = .systemFont(ofSize: 20)
+        label.textColor = .white
+        label.setKern()
+    }
+    
+    public func bindOutput() {
+        let output = viewModel.transform(input: input.eraseToAnyPublisher())
+        output.sink { [weak self] in
+            guard let self else { return }
+            switch $0 {
+            case .navigateToWaitingRoom(let isGuest):
+                self.present(waitingRoomViewController, animated: false)
+            }
+        }
+        .store(in: &cancellables)
+    }
+}

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/EnterLoadingViewController.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/EnterLoadingViewController.swift
@@ -63,7 +63,9 @@ public final class EnterLoadingViewController: BaseViewController, ViewControlle
     
     public func bindOutput() {
         let output = viewModel.transform(input: input.eraseToAnyPublisher())
-        output.sink { [weak self] in
+        output
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in
             guard let self else { return }
             switch $0 {
             case .navigateToWaitingRoom(let isGuest):

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/WaitingRoomViewController.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/WaitingRoomViewController.swift
@@ -73,7 +73,7 @@ public final class WaitingRoomViewController: BaseViewController, ViewController
         return WaitingRoomViewModel.Input(
             viewDidLoad: viewDidLoadPublisher,
             micMuteButtonDidTap: waitingRoomView.micButton.tapPublisher,
-            shareButtonDidTap: waitingRoomView.shareButton.tapPublisher,
+            linkButtonDidTap: waitingRoomView.linkButton.tapPublisher,
             startButtonDidTap: startButtonTapPublisher
         )
     }

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/WaitingRoomViewController.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/WaitingRoomViewController.swift
@@ -129,8 +129,8 @@ public final class WaitingRoomViewController: BaseViewController, ViewController
             self.participantsCollectionViewController.dataSource.apply(snapshot, animatingDifferences: true)
         }.store(in: &cancellables)
         
-        output.shouldShowToast.sink { [weak self] message in
-            print(message)
+        output.shouldShowShareSheet.sink { [weak self] message in
+            self?.showShareSheet(message: message)
         }.store(in: &cancellables)
     }
     
@@ -145,5 +145,13 @@ public final class WaitingRoomViewController: BaseViewController, ViewController
         snapshot.appendSections([0])
         snapshot.appendItems(placeHolder, toSection: 0)
         participantsCollectionViewController.dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
+    private func showShareSheet(message: String) {
+        let activityViewController = UIActivityViewController(
+            activityItems: [message],
+            applicationActivities: nil
+        )
+        present(activityViewController, animated: true)
     }
 }

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewModel/EnterLoadingViewModel.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewModel/EnterLoadingViewModel.swift
@@ -1,0 +1,45 @@
+import UIKit
+import Combine
+import PhotoGetherDomainInterface
+
+public final class EnterLoadingViewModel {
+    private var cancellables = Set<AnyCancellable>()
+    
+    public enum Input {
+        case viewDidLoad
+    }
+    
+    public enum Output {
+        case navigateToWaitingRoom(isGuest: Bool)
+    }
+    
+    private let _output = PassthroughSubject<Output, Never>()
+    public var output: AnyPublisher<Output, Never> { _output.eraseToAnyPublisher() }
+    
+    private let joinRoomUseCase: JoinRoomUseCase
+    
+    public init(joinRoomUseCase: JoinRoomUseCase) {
+        self.joinRoomUseCase = joinRoomUseCase
+    }
+    
+    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
+        input.sink { [weak self] in
+            guard let self else { return }
+            
+            switch $0 {
+            case .viewDidLoad:
+                self.requestJoinRoom()
+            }
+        }.store(in: &cancellables)
+        
+        return output
+    }
+    
+    private func requestJoinRoom() {
+        joinRoomUseCase.execute()
+            .sink { [weak self] isGuest in
+                self?._output.send(.navigateToWaitingRoom(isGuest: isGuest))
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewModel/WaitingRoomViewModel.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewModel/WaitingRoomViewModel.swift
@@ -6,7 +6,7 @@ public final class WaitingRoomViewModel {
     struct Input {
         let viewDidLoad: AnyPublisher<Void, Never>
         let micMuteButtonDidTap: AnyPublisher<Void, Never>
-        let shareButtonDidTap: AnyPublisher<Void, Never>
+        let linkButtonDidTap: AnyPublisher<Void, Never>
         let startButtonDidTap: AnyPublisher<Void, Never>
     }
 
@@ -24,20 +24,23 @@ public final class WaitingRoomViewModel {
     private let sendOfferUseCase: SendOfferUseCase
     private let getLocalVideoUseCase: GetLocalVideoUseCase
     private let getRemoteVideoUseCase: GetRemoteVideoUseCase
+    private let createRoomUseCase: CreateRoomUseCase
     
     public init(
         sendOfferUseCase: SendOfferUseCase,
         getLocalVideoUseCase: GetLocalVideoUseCase,
-        getRemoteVideoUseCase: GetRemoteVideoUseCase
+        getRemoteVideoUseCase: GetRemoteVideoUseCase,
+        createRoomUseCase: CreateRoomUseCase
     ) {
         self.sendOfferUseCase = sendOfferUseCase
         self.getLocalVideoUseCase = getLocalVideoUseCase
         self.getRemoteVideoUseCase = getRemoteVideoUseCase
+        self.createRoomUseCase = createRoomUseCase
     }
     
     func transform(input: Input) -> Output {
         let newMicMuteState = mutateMicMuteButtonDidTap(input)
-        let newShouldShowShareSheet = mutateShareButtonDidTap(input)
+        let newShouldShowShareSheet = mutateLinkButtonDidTap(input)
         let newNavigateToPhotoRoom = mutateStartButtonDidTap(input)
         
         let output = Output(
@@ -78,9 +81,10 @@ private extension WaitingRoomViewModel {
         }.eraseToAnyPublisher()
     }
     
-    func mutateShareButtonDidTap(_ input: Input) -> AnyPublisher<String, Never> {
-        input.shareButtonDidTap.map { [weak self] _ -> String in
+    func mutateLinkButtonDidTap(_ input: Input) -> AnyPublisher<String, Never> {
+        input.linkButtonDidTap.map { [weak self] _ -> String in
             guard let self else { return "레전드 에러 발생" }
+            self.createRoomUseCase.execute()
             self.sendOfferUseCase.execute()
             return "연결을 시도합니다."
         }

--- a/PhotoGetherServer/PhotoGetherServer/Sources/App/DTO/CreateRoomResponseDTO.swift
+++ b/PhotoGetherServer/PhotoGetherServer/Sources/App/DTO/CreateRoomResponseDTO.swift
@@ -3,8 +3,5 @@ import Foundation
 package struct CreateRoomResponseDTO: Encodable {
     let roomID: String
     let userID: String
-    
-    func toData(_ encoder: JSONEncoder) -> Data? {
-        return try? encoder.encode(self)
-    }
 }
+

--- a/PhotoGetherServer/PhotoGetherServer/Sources/App/Utils/ByteBuffer+toDTO.swift
+++ b/PhotoGetherServer/PhotoGetherServer/Sources/App/Utils/ByteBuffer+toDTO.swift
@@ -2,7 +2,7 @@ import Foundation
 import Vapor
 
 package extension ByteBuffer {
-    func toDTO<T: Decodable>(type: T.Type) -> T? {
-        return try? JSONDecoder().decode(type, from: self)
+    func toDTO<T: Decodable>(type: T.Type, decoder: JSONDecoder) -> T? {
+        return try? decoder.decode(type, from: self)
     }
 }

--- a/PhotoGetherServer/PhotoGetherServer/Sources/App/Utils/ByteBuffer+toDTO.swift
+++ b/PhotoGetherServer/PhotoGetherServer/Sources/App/Utils/ByteBuffer+toDTO.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Vapor
+
+package extension ByteBuffer {
+    func toDTO<T: Decodable>(type: T.Type) -> T? {
+        return try? JSONDecoder().decode(type, from: self)
+    }
+}

--- a/PhotoGetherServer/PhotoGetherServer/Sources/App/Utils/Encodable+toData.swift
+++ b/PhotoGetherServer/PhotoGetherServer/Sources/App/Utils/Encodable+toData.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Encodable {
+    func toData(_ encoder: JSONEncoder) -> Data? {
+        return try? encoder.encode(self)
+    }
+}

--- a/PhotoGetherServer/PhotoGetherServer/Sources/App/routes.swift
+++ b/PhotoGetherServer/PhotoGetherServer/Sources/App/routes.swift
@@ -9,24 +9,34 @@ func routes(_ app: Application) throws {
     var connectedClients = [WebSocket]()
     
     // WebSocket 연결을 처리하는 라우트
-    app.webSocket("signaling") { request, client in
+    app.webSocket("signaling") {
+        request,
+        client in
         connectedClients.append(client)
         
         // 클라이언트가 연결될 때 호출
         print("Client connected. Total connected clients: \(connectedClients.count)")
         
         // 클라이언트로부터 데이터를 수신할 때 호출
-        client.onBinary { client, data in
+        client.onBinary {
+            client,
+            data in
             print("Received binary data of size: \(data.readableBytes)")
             // TODO: 1. data -> JSON으로 디코딩
-            guard let requestType = data.toDTO(type: WebSocketRequestType.self) else {
+            guard let requestType = data.toDTO(
+                type: WebSocketRequestType.self,
+                decoder: decoder
+            ) else {
                 print("Decode Failed to WebSocketRequestType: \(data)")
                 return
             }
             
             switch requestType.messageType {
             case "signaling":
-                guard let request = data.toDTO(type: SignalingRequestDTO.self) else {
+                guard let request = data.toDTO(
+                    type: SignalingRequestDTO.self,
+                    decoder: decoder
+                ) else {
                     print("Decode Failed to SignalingRequestDTO: \(data)")
                     return
                 }
@@ -41,7 +51,10 @@ func routes(_ app: Application) throws {
                     .forEach { $0.send(data) }
                 
             case "createRoom":
-                guard let request = data.toDTO(type: RoomRequestDTO.self) else {
+                guard let request = data.toDTO(
+                    type: RoomRequestDTO.self,
+                    decoder: decoder
+                ) else {
                     print("Decode Failed to RoomRequestDTO: \(data)")
                     return
                 }


### PR DESCRIPTION
## 🤔 배경
4인 참가를 위해 방 생성/참가 기능을 구현해야 했습니다.

## 📃 작업 내역
- localVideoView 단일화
- 방 생성 기능 구현
- 방 참가 기능 50% 구현(서버로 요청 보내기만 구현됨)
- UIActivityViewController를 통한 딥링크 초대 기능 구현
- 게스트 입장 대기 화면(EnterLoadingViewController) 구현
- WebSocketClient Delegate Deprecated 및 Publisher 구현

## ✅ 리뷰 노트

## 🚀 localVideoView 단일화
기존에는 아래와 같이 ConnectionRepository에 있는 clients 배열에서 직접 localVideoView를 가져왔습니다.
```swift
public protocol ConnectionRepository {
    var clients: [ConnectionClient] { get }
}
```
하지만 이렇게 할 경우 각 ConnectionClient들이 localVideoView를 가지고 있어서 총 3개의 localVideoView가 생성됩니다.
그래서 localVideoView는 ConnectionRepository에서 하나만 관리할 수 있도록 리팩토링했습니다.
우선 ConnectionRepository는 아래와 같이 변경했습니다.
```swift
public protocol ConnectionRepository {
    var clients: [ConnectionClient] { get }
    var localVideoView: UIView { get }
    var capturedLocalVideo: UIImage? { get }
    ...
}
```
 하나의 localVideoView를 가지고 UseCase에서 접근이 가능하도록 했습니다. 그리고 ConnectionClient가 기존에 하나씩 생성해서 가지고 있던 localVideoView를 ConnectionRepository에 있는 localVideoView를 전달해서 사용하는 방식으로 바꿨습니다. 아래와 같이 bindLocalVideo 메서드를 사용해 Repository에 있는 localVideoView를 전달해서 바인딩해줄 수 있습니다. 
```swift
public protocol ConnectionClient {
    func bindLocalVideo(_ localVideoView: UIView)
}
```

## 🚀 방 생성 기능 구현
방 생성 기능은 아래와 같은 흐름으로 진행됩니다.
1. 호스트가 createRoom 명령을 서버로 보냄
2. 서버는 UUID를 이용해 roomID와 userID를 만들고 이를 토대로 방을 만들어 호스트를 방에 입장시킵니다.
3. 서버는 생성된 roomID와 userID를 데이터로 인코딩해서 호스트에게 다시 전달합니다. 

Request의 형태는 다음과 같습니다. messageType으로 방을 생성할 것인지 이미 생성된 방에 들어갈 것인지 명령을 구분합니다. message에는 해당 명령에 필요한 데이터를 담습니다. 이렇게 담은 정보를 인코딩해서 서버로 보내줍니다. 
```swift
struct RoomRequestDTO: WebSocketRequestable {
    var messageType: RoomMessageType
    var message: Data?
    
    init(messageType: RoomMessageType, message: Data? = nil) { }
    
    enum RoomMessageType: String, Encodable {
        case createRoom
        case joinRoom
    }
}
```
서버는 받은 정보를 디코딩하여 messageType을 분석하고 이에 해당하는 로직을 실행시킵니다. 그래서 createRoom의 명령이 들어오면 방을 생성하고 userID를 생성한 후 이를 구조체에 담아 인코딩하여 다시 호스트에게 전달합니다. 전달된 정보는 딥링크 URI 생성에 이용됩니다. 

## 🚀 방 참가 기능 50% 구현(서버로 요청 보내기만 구현됨)
현재 방 참가 기능은 딥링크 URI로 받은 roomID 정보를 담아서 서버에 joinRoom의 messageType을 가진 명령을 전달하는 것 까지만 구현되어 있습니다. 
```swift 
public struct JoinRoomRequestMessage: Encodable {
    public let roomID: String
}
```
JoinRoomRequest의 메시지에는 위의 정보가 담겨서 서버로 전달됩니다. 이후 서버에서 이를 토대로 방에 입장할 수 있는 로직을 구현할 계획입니다.


## 🚀 UIActivityViewController를 통한 딥링크 초대 기능 구현

카톡으로 공유하면 아래와 같은 형태로 URI Scheme을 전달하고, 누르면 딥링크 방식을 통해 아래 **게스트 입장 대기 화면**으로 진입하게 됩니다.

<img src="https://github.com/user-attachments/assets/956b6dc8-cd79-452b-8226-7ab61c647213" width="40%">



## 🚀 게스트 입장 대기 화면(EnterLoadingViewController) 구현

> 텍스트 정렬 안맞는 문제는 가운데 정렬로 수정되었습니다 ! 스샷 귀차니즘 이슈로..

게스트 입장 대기 화면 ViewDidLoad 시점에 방 참가 요청을 보내게 됩니다.
그리고 방 참가 성공 여부에 따라 아래와 같이 분기 처리 됩니다.
- 방 참가 성공 시: 게스트 입장으로 WaitingRoomViewController로 진입
- 방 참가 실패 시: 호스트 입장으로 WaitingRoomViewController로 진입

<img src="https://github.com/user-attachments/assets/e18460ae-676b-4bbd-acc4-ca954290453b" width="40%">



## 🚀 WebSocketClient Delegate Deprecated 및 Publisher 구현

WebSocketClient는 이벤트를 전달하려면 Delegate를 사용해야 했습니다. 하지만 아래와 같이 여러 서비스들에서 하나의 WebSocketClient를 바라보게 되었고, Delegate 배열을 관리해야 했습니다. Delegate를 배열로 관리한다면 위임자(Delegate)라는 패턴의 의미와 맞지 않았고, Delegate의 순환 참조 위험성도 증가한다는 문제가 있었습니다. 


<img src="https://github.com/user-attachments/assets/bc3454c4-4e02-44a7-b362-b8fea9d43aa3" width="50%">


그래서 아래와 같이 WebSocketClient 내에 Publisher들을 두어 필요한 이벤트들만 구독할 수 있도록 변경했습니다.


<img src="https://github.com/user-attachments/assets/9a8cd6f5-1c81-4ed7-b24a-4d8d9913a91f" width="50%">



아직 모든 서비스들에서 WebSocketClientDelegate를 제거하지 못해 아래 코드와 같이 deprecated 시키고, 차차 걷어내려고 합니다.
그리고 클래스 내부에선 subject에 접근이 가능하고, 외부에는 publisher만 노출되도록 해 subject의 편리함은 가져가되 외부에서 send할 수 없는 단방향 구조를 만들었습니다.

```swift
public final class WebSocketClientImpl: NSObject, WebSocketClient {
    @available(*, deprecated, message: "Publisher로 교체될 예정입니다.")
    public var delegates: [WebSocketClientDelegate] = []

    private let _webSocketDidConnectPublisher = PassthroughSubject<Void, Never>()
    private let _webSocketDidDisconnectPublisher = PassthroughSubject<Void, Never>()
    private let _webSocketdidReceiveDataPublisher = PassthroughSubject<Data, Never>()

    public var webSocketDidConnectPublisher: AnyPublisher<Void, Never> {
        _webSocketDidConnectPublisher.eraseToAnyPublisher()
    }
    public var webSocketDidDisconnectPublisher: AnyPublisher<Void, Never> {
        _webSocketDidDisconnectPublisher.eraseToAnyPublisher()
    }
    public var webSocketdidReceiveDataPublisher: AnyPublisher<Data, Never> {
        _webSocketdidReceiveDataPublisher.eraseToAnyPublisher()
    }
}
```

## 🚀 테스트 방법

링크 버튼을 누르면 공유 시트가 올라오고, 딥링크 가능한 URI Scheme을 공유할 수 있습니다.
그리고 외부에서 해당 메시지를 누르면 게스트 모드로 앱에 진입합니다.
현재는 아래와 같이 **서버 요청없이** 3초 뒤에 WaitingRoom으로 이동되게 되어있습니다.


<img src="https://github.com/user-attachments/assets/5d2d1a7f-11c9-494c-8a3b-846d4d32d2e6" width="70%">


