### PR TITLE
[FIX/#100] 스크롤뷰 컨텐츠 센터링 + 줌 문제 해결

### DIFF
--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/CanvasScrollView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/CanvasScrollView.swift
@@ -34,7 +34,10 @@ final class CanvasScrollView: UIScrollView {
     
     func updateFrameImage(to image: UIImage) {
         imageView.image = image
-        imageView.sizeToFit()
+        
+        self.imageView.sizeToFit()
+        self.setupZoomScale()
+        self.contentCentering()
     }
     
     func contentCentering() {
@@ -70,7 +73,6 @@ final class CanvasScrollView: UIScrollView {
 
 extension CanvasScrollView: UIScrollViewDelegate {
     public func viewForZooming(in scrollView: UIScrollView) -> UIView? {
-        contentCentering()
         return imageView
     }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/CanvasScrollView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/CanvasScrollView.swift
@@ -62,8 +62,9 @@ final class CanvasScrollView: UIScrollView {
         let heightBaseScale = frame.height / image.size.height
         let calculatedZoomScale = min(widthBaseScale, heightBaseScale)
         
-        zoomScale = calculatedZoomScale
+        // 호출 순서 바꾸면 안됨
         minimumZoomScale = calculatedZoomScale
+        zoomScale = calculatedZoomScale
     }
 }
 

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
@@ -36,13 +36,6 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
         bindOutput()
     }
     
-    public override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        canvasScrollView.setupZoomScale()
-        canvasScrollView.contentCentering()
-    }
-    
     public func addViews() {
         [navigationView, canvasScrollView, bottomView].forEach {
             view.addSubview($0)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -35,13 +35,6 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
         bindOutput()
     }
     
-    public override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        
-        canvasScrollView.setupZoomScale()
-        canvasScrollView.contentCentering()
-    }
-    
     public func addViews() {
         [navigationView, canvasScrollView, bottomView].forEach {
             view.addSubview($0)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -74,8 +74,6 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
         navigationView.backgroundColor = .yellow
         bottomView.backgroundColor = .yellow
         canvasScrollView.backgroundColor = .red
-        
-        canvasScrollView.imageView.sizeToFit()
     }
     
     public func bindInput() {


### PR DESCRIPTION
## 🤔 배경
- Navigation으로 화면에 접근했을 때 content의 위치가 불안정하던 문제가 있었음
- Content 내부 스티커를 터치할 때 SubView가 다시 그려지면서 콘텐츠 센터링이 계속 잡히던 문제가 있었음

## 📃 작업 내역
- Navigation으로 들어와도 Content의 위치가 중앙이도록 수정
- Content에 추가적인 작업이 있어도 사용자의 의도를 해치지 않도록 수정

## ✅ 리뷰 노트
### 1. image가 있기 전에 content 영역을 잡으려 함

`CanvasScrollView`의 내부 **ContentView**의 위치를 잡기 위해서는 아래 두개의 메서드를 사용합니다. 그런데 두 메서드 전부 **self.imageView.image에 의존**을 하고 있습니다.

하지만 `imageView`의 **image**는 `updateFrameImage(to: )` 메서드가 **bind로 인해 호출되는 시점**에 들어오고 있다보니 image가 없는 상황에서 영역을 설정해주려 하니 생긴 문제였습니다.

이젠 깔쌈하게 해결 했습니다 👍

#### **CanvasScrollView.swift**

```swift
func contentCentering() {
    let scrollView = self
    let contentView = imageView

    ...
}

func setupZoomScale() {
    guard let image = imageView.image else { return }
    
    ...
}
```

### 2. 코드 호출 순서

`zoomScale`을 세팅해주는 메서드를 다른 곳으로 옮겨서 호출하거나, Cycle이나 Render 타이밍을 더욱 뒤로 하는 별 짓을 다 해봤는데 여전히 `ZoomScale`을 생성 시점 이후 특정 액션(버튼, Scrolling, ...)을 통해서 계속 잡아줘야지만 잡히는 문제가 있었습니다.

메서드 내부에서 코드 순서의 문제인가 싶어 살짝 바꿔주니까 갑분 정상작동 ㄹㅇㅋㅋ

#### **CanvasScrollView.swift**

- `calculatedZoomScale`을 할당해주는 순서에 따라 결과가 달라짐
- 아마도 최소 `zoomScale`이 정해지지 않은 상황에서 `zoomScale`을 할당해주다보니 발생한것으로 보임

```swift
func setupZoomScale() {
    ...
    
    // 호출 순서 바꾸면 안됨
    minimumZoomScale = calculatedZoomScale
    zoomScale = calculatedZoomScale
}
```


## 🎨 스크린샷
| iPhone 16 Pro Max & iPhone SE(2세대) |
| -------------- |
| ![에러 상황 개선 영상](https://github.com/user-attachments/assets/80b421d3-8715-4f44-a780-aa9cf3d82cb6) |


## 🚀 테스트 방법
1. EditPhotoDemo를 실행해줍니다
2. SendOffer 버튼을 눌러줍니다(한쪽만)
3. 한쪽은 Host, 다른 쪽은 Guest로 들어가줍니다
4. 편집 상황이라 생각하고 편하게 즐기시면 됩니다 👍
