### PR TITLE
[FEAT]/#101 프레임 이벤트 비즈니스 로직 구현

### DIFF
--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
@@ -3,13 +3,15 @@ import Combine
 import PhotoGetherDomainInterface
 
 public final class EventConnectionGuestRepositoryImpl: EventConnectionRepository {
-    public var clients: [ConnectionClient]
-    private var cancellables: Set<AnyCancellable> = []
+    private let clients: [ConnectionClient]
+    
     private let receiveDataFromHost = PassthroughSubject<[StickerEntity], Never>()
     private let receiveDataFromHostFrame = PassthroughSubject<FrameEntity, Never>()
     
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
+    
+    private var cancellables: Set<AnyCancellable> = []
     
     public init(clients: [ConnectionClient]) {
         self.clients = clients

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
@@ -57,9 +57,23 @@ public final class EventConnectionGuestRepositoryImpl: EventConnectionRepository
     }
     
     public func receiveStickerList() -> AnyPublisher<[StickerEntity], Never> {
-        return receiveDataFromHost
-            .decode(type: [StickerEntity].self, decoder: decoder)
-            .replaceError(with: [])
-            .eraseToAnyPublisher()
+        return receiveDataFromHost.eraseToAnyPublisher()
+    }
+    
+    public func mergeFrame(type: EventType, frame: FrameEntity) {
+        let frameEvent = EventEntity(
+            type: type,
+            timeStamp: Date(),
+            payload: EventPayload.frame(frame)
+        )
+        
+        guard let encodedFrameEvent = try? encoder.encode(frameEvent) else { return }
+
+        // TODO: 추후 Host를 특정하기
+        clients.first?.sendData(data: encodedFrameEvent)
+    }
+    
+    public func receiveFrameEntity() -> AnyPublisher<FrameEntity, Never> {
+        return receiveDataFromHostFrame.eraseToAnyPublisher()
     }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
@@ -23,10 +23,7 @@ public final class EventConnectionGuestRepositoryImpl: EventConnectionRepository
     }
     
     private func bindData() {
-        // MARK: Host로 부터 들어오는 Data를 send한다.
-        // clients.filter { $0 == .host }
-        // receiveDataFromHost.send(Data())
-        
+        // TODO: 추후 Host를 특정하기
         clients.first?.receivedDataPublisher
             .sink(receiveValue: { [weak self] data in
                 guard let payload = try? self?.decoder.decode(EventPayload.self, from: data) else { return }
@@ -55,10 +52,7 @@ public final class EventConnectionGuestRepositoryImpl: EventConnectionRepository
         
         guard let encodedStickerEvent = try? stickerEvent.encode() else { return }
         
-        // MARK: Host의 Client를 특정한다.
-        // clients.filter { $0 == .host }
-        
-        // 자신의 이벤트를 전달한다. // MARK: hostClient.sendData()
+        // TODO: 추후 Host를 특정하기
         clients.first?.sendData(data: encodedStickerEvent)
     }
     

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
@@ -39,7 +39,7 @@ public final class EventConnectionGuestRepositoryImpl: EventConnectionRepository
         let stickerEvent = EventEntity(
             type: type,
             timeStamp: Date(),
-            entity: sticker
+            entity: EntityType.sticker(sticker)
         )
         
         guard let encodedStickerEvent = try? stickerEvent.encode() else { return }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
@@ -39,7 +39,7 @@ public final class EventConnectionGuestRepositoryImpl: EventConnectionRepository
         let stickerEvent = EventEntity(
             type: type,
             timeStamp: Date(),
-            entity: EntityType.sticker(sticker)
+            payload: EventPayload.sticker(sticker)
         )
         
         guard let encodedStickerEvent = try? stickerEvent.encode() else { return }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionGuestRepositoryImpl.swift
@@ -7,18 +7,18 @@ public final class EventConnectionGuestRepositoryImpl: EventConnectionRepository
     private var cancellables: Set<AnyCancellable> = []
     private var receiveDataFromHost = PassthroughSubject<Data, Never>()
     
-    private let decoder: JSONDecoder
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
     
     public init(clients: [ConnectionClient]) {
         self.clients = clients
-        self.decoder = JSONDecoder()
-        
-        setupDecoder()
+        setupCoder()
         bindData()
     }
     
-    private func setupDecoder() {
+    private func setupCoder() {
         decoder.dateDecodingStrategy = .iso8601
+        encoder.dateEncodingStrategy = .iso8601
     }
     
     private func bindData() {

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
@@ -8,10 +8,18 @@ public final class EventConnectionHostRepositoryImpl: EventConnectionRepository 
     private var cancellables: Set<AnyCancellable> = []
     private var receiveDataFromGuest = PassthroughSubject<Data, Never>()
     private var sendToViewModel = PassthroughSubject<[StickerEntity], Never>()
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
     
     public init(clients: [ConnectionClient]) {
         self.clients = clients
+        setupCoder()
         bindData()
+    }
+    
+    private func setupCoder() {
+        decoder.dateDecodingStrategy = .iso8601
+        encoder.dateEncodingStrategy = .iso8601
     }
     
     private func bindData() {

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
@@ -73,12 +73,12 @@ public final class EventConnectionHostRepositoryImpl: EventConnectionRepository 
     }
     
     public func mergeSticker(type: EventType, sticker: StickerEntity) {
-        let sticketEvent = EventEntity(
+        let stickerEvent = EventEntity(
             type: type,
             timeStamp: Date(),
             payload: EventPayload.sticker(sticker)
         )
-        eventHub.push(event: sticketEvent)
+        eventHub.push(event: stickerEvent)
     }
     
     public func receiveFrameEntity() -> AnyPublisher<FrameEntity, Never> {

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
@@ -50,7 +50,11 @@ public final class EventConnectionHostRepositoryImpl: EventConnectionRepository 
     }
     
     public func mergeSticker(type: EventType, sticker: StickerEntity) {
-        let sticketEvent = EventEntity(type: type, timeStamp: Date(), entity: sticker)
+        let sticketEvent = EventEntity(
+            type: type,
+            timeStamp: Date(),
+            entity: EntityType.sticker(sticker)
+        )
         eventHub.push(event: sticketEvent)
     }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
@@ -34,7 +34,7 @@ public final class EventConnectionHostRepositoryImpl: EventConnectionRepository 
             .store(in: &cancellables)
         
         // MARK: EventHub에서 처리된 Event를 (GuestClient + HostView)에게 전파한다.
-        eventHub.resultEventPublisher
+        eventHub.stickerListPublisher
             .sink { [weak self] entityList in
                 guard let encodedData = try? entityList.encode() else { return }
                 print("DEBUG: EventHub Result Send")

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
@@ -77,4 +77,17 @@ public final class EventConnectionHostRepositoryImpl: EventConnectionRepository 
         )
         eventHub.push(event: sticketEvent)
     }
+    
+    public func receiveFrameEntity() -> AnyPublisher<FrameEntity, Never> {
+        return sendToViewModelFrame.eraseToAnyPublisher()
+    }
+    
+    public func mergeFrame(type: EventType, frame: FrameEntity) {
+        let frameEvent = EventEntity(
+            type: type,
+            timeStamp: Date(),
+            payload: EventPayload.frame(frame)
+        )
+        eventHub.push(event: frameEvent)
+    }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
@@ -53,7 +53,7 @@ public final class EventConnectionHostRepositoryImpl: EventConnectionRepository 
         let sticketEvent = EventEntity(
             type: type,
             timeStamp: Date(),
-            entity: EntityType.sticker(sticker)
+            payload: EventPayload.sticker(sticker)
         )
         eventHub.push(event: sticketEvent)
     }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventConnection/EventConnectionHostRepositoryImpl.swift
@@ -3,15 +3,18 @@ import Combine
 import PhotoGetherDomainInterface
 
 public final class EventConnectionHostRepositoryImpl: EventConnectionRepository {
-    public var clients: [ConnectionClient]
+    private let clients: [ConnectionClient]
+    
     private let eventHub = EventHub()
-    private var cancellables: Set<AnyCancellable> = []
-    private var receiveDataFromGuest = PassthroughSubject<Data, Never>()
+    
+    private let receiveDataFromGuest = PassthroughSubject<Data, Never>()
     private let sendToViewModel = PassthroughSubject<[StickerEntity], Never>()
     private let sendToViewModelFrame = PassthroughSubject<FrameEntity, Never>()
     
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
+    
+    private var cancellables: Set<AnyCancellable> = []
     
     public init(clients: [ConnectionClient]) {
         self.clients = clients

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
@@ -78,6 +78,8 @@ final class EventHub {
             return isStickerReady
         case .frame:
             return isFrameReady
+        default:
+            return false
         }
     }
 

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
@@ -35,7 +35,11 @@ final class EventHub {
     private var eventQueue = EventQueue() // TODO: 추후 Priority queue로 변경
     
     var stickerListPublisher: AnyPublisher<[StickerEntity], Never> {
-        stickerEventManager.broadcastPublisher.eraseToAnyPublisher()
+        return stickerEventManager.broadcastPublisher.eraseToAnyPublisher()
+    }
+    
+    var framePublisher: AnyPublisher<FrameEntity, Never> {
+        return frameEventManager.broadcastPublisher.eraseToAnyPublisher()
     }
     
     private var cancellables = Set<AnyCancellable>()

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
@@ -43,7 +43,14 @@ final class EventHub {
                     debugPrint("popLast 에러")
                     return
                 }
-                self?.eventManager.work(event: currentEvent)
+                
+                switch currentEvent.payload {
+                case .sticker(let stickerEntity):
+                    self?.eventManager.work(type: currentEvent.type, with: stickerEntity)
+                case .frame(let frameEntity):
+                    // TODO: FrameManager
+                    break
+                }
             }
             .store(in: &cancellables)
     }
@@ -64,87 +71,88 @@ final class EventManager {
         return stickerDictionary.compactMap { $0.value }
     }
     
-    func work(event: EventEntity) {
+    func work(type: EventType, with sticker: StickerEntity) {
         callEventPublisher.send(false)
-        switch event.type {
-        case .create: createEvent(by: event)
-        case .delete: deleteEvent(by: event)
-        case .update: updateEvent(to: event)
-        case .unlock: unlockEvent(to: event)
+        switch type {
+        case .create: createEvent(by: sticker)
+        case .delete: deleteEvent(by: sticker)
+        case .update: updateEvent(by: sticker)
+        case .unlock: unlockEvent(by: sticker)
         }
         callEventPublisher.send(true)
     }
     
-    private func createEvent(by event: EventEntity) {
-        guard isObejctDeleted[event.entity.id] == nil else {
-            debugPrint("Create event 실패")
-            return
-        }
-        guard stickerDictionary[event.entity.id] == nil else {
+    private func createEvent(by sticker: StickerEntity) {
+        guard isObejctDeleted[sticker.id] == nil else {
             debugPrint("Create event 실패")
             return
         }
         
-        stickerDictionary[event.entity.id] = event.entity
-        isObejctDeleted[event.entity.id] = false
+        guard stickerDictionary[sticker.id] == nil else {
+            debugPrint("Create event 실패")
+            return
+        }
+        
+        stickerDictionary[sticker.id] = sticker
+        isObejctDeleted[sticker.id] = false
         
         // MARK: event가 아니라 전체 딕셔너리 보내기
         resultEventPublihser.send(currenntStickerList)
     }
     
-    private func deleteEvent(by event: EventEntity) {
-        guard isObejctDeleted[event.entity.id] == false,            // 이미 지워진 객체를 지우려 할 때
-              let oldSticker = stickerDictionary[event.entity.id]   // 해당 스티커가 없을 때(전파 받기 전에 지워짐)
+    private func deleteEvent(by sticker: StickerEntity) {
+        guard isObejctDeleted[sticker.id] == false,            // 이미 지워진 객체를 지우려 할 때
+              let oldSticker = stickerDictionary[sticker.id]   // 해당 스티커가 없을 때(전파 받기 전에 지워짐)
         else {
             // 이미 처리된 상황이기에 아무 처리를 하지 않아도 문제가 없음
             debugPrint("A/B 삭제 경쟁 상황에서 이미 처리된 삭제를 요청함")
             return
         }
         
-        guard let newOwner = event.entity.owner else { return }
+        guard let newOwner = sticker.owner else { return }
 
         if oldSticker.owner == nil || oldSticker.owner == newOwner {
             // OldOwner가 nil이거나 Old,New Owner가 서로 같을 때
-            stickerDictionary[event.entity.id] = nil
-            isObejctDeleted[event.entity.id] = true
+            stickerDictionary[sticker.id] = nil
+            isObejctDeleted[sticker.id] = true
             
             resultEventPublihser.send(currenntStickerList)
         }
     }
     
-    private func updateEvent(to event: EventEntity) {
-        guard isObejctDeleted[event.entity.id] == false,            // 이미 지워진 객체를 업데이트 하려 할 때
-              let oldSticker = stickerDictionary[event.entity.id]   // 해당 스티커가 없을 때(전파 받기 전에 지워짐)
+    private func updateEvent(by sticker: StickerEntity) {
+        guard isObejctDeleted[sticker.id] == false,            // 이미 지워진 객체를 업데이트 하려 할 때
+              let oldSticker = stickerDictionary[sticker.id]   // 해당 스티커가 없을 때(전파 받기 전에 지워짐)
         else {
             // 이미 처리된 상황이기에 아무 처리를 하지 않아도 문제가 없음
             debugPrint("A/B 경쟁 상황에서 이미 삭제된 객체의 업데이트를 요청함")
             return
         }
         
-        guard let newOwner = event.entity.owner else { return }
+        guard let newOwner = sticker.owner else { return }
 
         if oldSticker.owner == nil || oldSticker.owner == newOwner {
             // OldOwner가 nil이거나 Old,New Owner가 서로 같을 때
-            stickerDictionary[event.entity.id] = event.entity
+            stickerDictionary[sticker.id] = sticker
 
             resultEventPublihser.send(currenntStickerList)
         }
     }
     
-    private func unlockEvent(to event: EventEntity) {
-        guard isObejctDeleted[event.entity.id] == false,
-              let oldSticker = stickerDictionary[event.entity.id]
+    private func unlockEvent(by sticker: StickerEntity) {
+        guard isObejctDeleted[sticker.id] == false,
+              let oldSticker = stickerDictionary[sticker.id]
         else {
             // 이미 처리된 상황이기에 아무 처리를 하지 않아도 문제가 없음
             debugPrint("A/B 경쟁 상황에서 이미 삭제된 객체의 언락을 요청함")
             return
         }
         
-        if oldSticker.owner == event.entity.owner {
-            var newSticker = stickerDictionary[event.entity.id]
+        if oldSticker.owner == sticker.owner {
+            var newSticker = stickerDictionary[sticker.id]
             newSticker?.updateOwner(to: nil)
             
-            stickerDictionary[event.entity.id] = newSticker
+            stickerDictionary[sticker.id] = newSticker
             resultEventPublihser.send(currenntStickerList)
         }
     }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EventHub/EventHub.swift
@@ -5,21 +5,21 @@ import PhotoGetherDomainInterface
 final class EventQueue {
     private var queue = [EventEntity]()
     
-    private let isEmptySubject = PassthroughSubject<Bool, Never>()
+    private let isExistSubject = PassthroughSubject<Bool, Never>()
     
-    var isEmptyPublisher: AnyPublisher<Bool, Never> {
-        return isEmptySubject.eraseToAnyPublisher()
+    var isExist: AnyPublisher<Bool, Never> {
+        return isExistSubject.eraseToAnyPublisher()
     }
     
     func push(event: EventEntity) {
         queue.append(event)
         queue.sort { $0.timeStamp > $1.timeStamp }
-        isEmptySubject.send(true)
+        isExistSubject.send(true)
     }
     
     func popLast() -> EventEntity? {
         let popLast = queue.popLast()
-        if queue.isEmpty { isEmptySubject.send(false) }
+        if queue.isEmpty { isExistSubject.send(false) }
         
         return popLast
     }
@@ -49,7 +49,7 @@ final class EventHub {
     }
     
     private func bind() {
-        eventQueue.isEmptyPublisher
+        eventQueue.isExist
             .combineLatest(stickerEventManager.isReady, frameEventManager.isReady)
             .filter { $0 && ($1 || $2) } // MARK: (큐에 내보낼 이벤트가 있음) && (스티커 매니저가 준비됨 || 프레임 매니저가 준비됨) -> 보낸다
             .map { ($1, $2) }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/ReceiveFrameUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/ReceiveFrameUseCaseImpl.swift
@@ -1,0 +1,15 @@
+import Combine
+import Foundation
+import PhotoGetherDomainInterface
+
+public final class ReceiveFrameUseCaseImpl: ReceiveFrameUseCase {
+    private let eventConnectionRepository: EventConnectionRepository
+    
+    public init(eventConnectionRepository: EventConnectionRepository) {
+        self.eventConnectionRepository = eventConnectionRepository
+    }
+    
+    public func execute() -> AnyPublisher<FrameEntity, Never> {
+        return eventConnectionRepository.receiveFrameEntity().eraseToAnyPublisher()
+    }
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/SendFrameToRepositoryUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/SendFrameToRepositoryUseCaseImpl.swift
@@ -1,0 +1,14 @@
+import Foundation
+import PhotoGetherDomainInterface
+
+public final class SendFrameToRepositoryUseCaseImpl: SendFrameToRepositoryUseCase {
+    public func execute(type: EventType, frame: FrameEntity) {
+        eventConnectionRepository.mergeFrame(type: type, frame: frame)
+    }
+    
+    private let eventConnectionRepository: EventConnectionRepository
+    
+    public init(eventConnectionRepository: EventConnectionRepository) {
+        self.eventConnectionRepository = eventConnectionRepository
+    }
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/EventEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/EventEntity.swift
@@ -8,18 +8,18 @@ public struct EventEntity: Equatable, Codable {
     private(set) var id: UUID
     public let type: EventType
     public let timeStamp: Date
-    public let entity: EntityType
+    public let payload: EventPayload
     
     public init(
         id: UUID = UUID(),
         type: EventType,
         timeStamp: Date,
-        entity: EntityType
+        payload: EventPayload
     ) {
         self.id = id
         self.type = type
         self.timeStamp = timeStamp
-        self.entity = entity
+        self.payload = payload
     }
 }
 
@@ -40,7 +40,7 @@ extension EventEntity {
         return try decoder.decode(EventEntity.self, from: data)
     }
 }
-public enum EntityType: Codable {
+public enum EventPayload: Codable {
     case sticker(StickerEntity)
     case frame(FrameEntity)
 

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/EventEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/EventEntity.swift
@@ -46,10 +46,12 @@ extension EventEntity {
 public enum EventPayload: Codable {
     case sticker(StickerEntity)
     case frame(FrameEntity)
+    case stickerList([StickerEntity]) // 새로운 case 추가
 
     private enum EntityTypeKey: String, Codable {
         case sticker
         case frame
+        case stickerList // 새로운 키 추가
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -66,6 +68,8 @@ public enum EventPayload: Codable {
             self = .sticker(try container.decode(StickerEntity.self, forKey: .data))
         case .frame:
             self = .frame(try container.decode(FrameEntity.self, forKey: .data))
+        case .stickerList: // stickerList 추가
+            self = .stickerList(try container.decode([StickerEntity].self, forKey: .data))
         }
     }
 
@@ -79,6 +83,9 @@ public enum EventPayload: Codable {
         case .frame(let frameEntity):
             try container.encode(EntityTypeKey.frame, forKey: .type)
             try container.encode(frameEntity, forKey: .data)
+        case .stickerList(let stickerList): // stickerList 인코딩 추가
+            try container.encode(EntityTypeKey.stickerList, forKey: .type)
+            try container.encode(stickerList, forKey: .data)
         }
     }
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/EventEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/EventEntity.swift
@@ -8,13 +8,13 @@ public struct EventEntity: Equatable, Codable {
     private(set) var id: UUID
     public let type: EventType
     public let timeStamp: Date
-    public let entity: StickerEntity
+    public let entity: EntityType
     
     public init(
         id: UUID = UUID(),
         type: EventType,
         timeStamp: Date,
-        entity: StickerEntity
+        entity: EntityType
     ) {
         self.id = id
         self.type = type
@@ -38,5 +38,44 @@ extension EventEntity {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return try decoder.decode(EventEntity.self, from: data)
+    }
+}
+public enum EntityType: Codable {
+    case sticker(StickerEntity)
+    case frame(FrameEntity)
+
+    private enum EntityTypeKey: String, Codable {
+        case sticker
+        case frame
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case data
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(EntityTypeKey.self, forKey: .type)
+        
+        switch type {
+        case .sticker:
+            self = .sticker(try container.decode(StickerEntity.self, forKey: .data))
+        case .frame:
+            self = .frame(try container.decode(FrameEntity.self, forKey: .data))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        switch self {
+        case .sticker(let stickerEntity):
+            try container.encode(EntityTypeKey.sticker, forKey: .type)
+            try container.encode(stickerEntity, forKey: .data)
+        case .frame(let frameEntity):
+            try container.encode(EntityTypeKey.frame, forKey: .type)
+            try container.encode(frameEntity, forKey: .data)
+        }
     }
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/EventEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/EventEntity.swift
@@ -23,6 +23,7 @@ public struct EventEntity: Equatable, Codable {
     }
 }
 
+@frozen
 public enum EventType: Codable {
     case create, update, delete, unlock
 }
@@ -40,6 +41,8 @@ extension EventEntity {
         return try decoder.decode(EventEntity.self, from: data)
     }
 }
+
+@frozen
 public enum EventPayload: Codable {
     case sticker(StickerEntity)
     case frame(FrameEntity)

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/FrameEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/FrameEntity.swift
@@ -23,6 +23,7 @@ public struct FrameEntity: Equatable, Codable {
     }
 }
 
+@frozen
 public enum FrameType: Codable {
     case defaultBlack
     case defaultWhite

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/FrameEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/FrameEntity.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public struct FrameEntity: Equatable, Codable {
+    public static func == (lhs: FrameEntity, rhs: FrameEntity) -> Bool {
+        return lhs.frameType == rhs.frameType
+    }
+    
+    public let id: UUID
+    public let frameType: FrameType
+    public private(set) var owner: String?
+    public private(set) var latestUpdated: Date
+    
+    public init(
+        id: UUID = UUID(),
+        frameType: FrameType,
+        owner: String?,
+        latestUpdated: Date
+    ) {
+        self.id = id
+        self.frameType = frameType
+        self.owner = owner
+        self.latestUpdated = latestUpdated
+    }
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/FrameEntity.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/FrameEntity.swift
@@ -22,3 +22,8 @@ public struct FrameEntity: Equatable, Codable {
         self.latestUpdated = latestUpdated
     }
 }
+
+public enum FrameType: Codable {
+    case defaultBlack
+    case defaultWhite
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/EventConnectionRepository.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/EventConnectionRepository.swift
@@ -4,4 +4,7 @@ import Foundation
 public protocol EventConnectionRepository {
     func receiveStickerList() -> AnyPublisher<[StickerEntity], Never>
     func mergeSticker(type: EventType, sticker: StickerEntity)
+    
+    func receiveFrameEntity() -> AnyPublisher<FrameEntity, Never>
+    func mergeFrame(type: EventType, frame: FrameEntity)
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/ReceiveFrameUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/ReceiveFrameUseCase.swift
@@ -1,0 +1,5 @@
+import Combine
+
+public protocol ReceiveFrameUseCase {
+    func execute() -> AnyPublisher<FrameEntity, Never>
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/SendFrameToRepositoryUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/SendFrameToRepositoryUseCase.swift
@@ -1,0 +1,6 @@
+import Combine
+import Foundation
+
+public protocol SendFrameToRepositoryUseCase {
+    func execute(type: EventType, frame: FrameEntity)
+}

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -20,12 +20,15 @@ public final class EditPhotoRoomGuestViewModel {
     private let frameImageGenerator: FrameImageGenerator
     private let fetchEmojiListUseCase: FetchEmojiListUseCase
     private let receiveStickerListUseCase: ReceiveStickerListUseCase
+    private let receiveFrameUseCase: ReceiveFrameUseCase
     private let sendStickerToRepositoryUseCase: SendStickerToRepositoryUseCase
+    private let sendFrameToRepositoryUseCase: SendFrameToRepositoryUseCase
     
     private var emojiList: [EmojiEntity] = [] // MARK: 추후 삭제 예정
     private let owner = "GUEST" + UUID().uuidString.prefix(4) // MARK: 임시 값(추후 ConnectionClient에서 받아옴)
     
     private let stickerObjectListSubject = CurrentValueSubject<[StickerEntity], Never>([])
+    private let frameImageSubject = PassthroughSubject<FrameType, Never>()
     
     private var cancellables = Set<AnyCancellable>()
     private var output = PassthroughSubject<Output, Never>()
@@ -34,12 +37,16 @@ public final class EditPhotoRoomGuestViewModel {
         frameImageGenerator: FrameImageGenerator,
         fetchEmojiListUseCase: FetchEmojiListUseCase,
         receiveStickerListUseCase: ReceiveStickerListUseCase,
-        sendStickerToRepositoryUseCase: SendStickerToRepositoryUseCase
+        receiveFrameUseCase: ReceiveFrameUseCase,
+        sendStickerToRepositoryUseCase: SendStickerToRepositoryUseCase,
+        sendFrameToRepositoryUseCase: SendFrameToRepositoryUseCase
     ) {
         self.frameImageGenerator = frameImageGenerator
         self.fetchEmojiListUseCase = fetchEmojiListUseCase
         self.receiveStickerListUseCase = receiveStickerListUseCase
+        self.receiveFrameUseCase = receiveFrameUseCase
         self.sendStickerToRepositoryUseCase = sendStickerToRepositoryUseCase
+        self.sendFrameToRepositoryUseCase = sendFrameToRepositoryUseCase
         bind()
     }
     
@@ -52,9 +59,21 @@ public final class EditPhotoRoomGuestViewModel {
             }
             .store(in: &cancellables)
         
+        frameImageSubject
+            .sink { [weak self] frameType in
+                
+            }
+            .store(in: &cancellables)
+        
         receiveStickerListUseCase.execute()
             .sink { [weak self] receivedStickerList in
                 self?.stickerObjectListSubject.send(receivedStickerList)
+            }
+            .store(in: &cancellables)
+
+        receiveFrameUseCase.execute()
+            .sink { [weak self] receivedFrame in
+                
             }
             .store(in: &cancellables)
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -20,12 +20,15 @@ public final class EditPhotoRoomHostViewModel {
     private let frameImageGenerator: FrameImageGenerator
     private let fetchEmojiListUseCase: FetchEmojiListUseCase
     private let receiveStickerListUseCase: ReceiveStickerListUseCase
+    private let receiveFrameUseCase: ReceiveFrameUseCase
     private let sendStickerToRepositoryUseCase: SendStickerToRepositoryUseCase
+    private let sendFrameToRepositoryUseCase: SendFrameToRepositoryUseCase
     
     private var emojiList: [EmojiEntity] = [] // MARK: 추후 삭제 예정
     private let owner = "Host" + UUID().uuidString.prefix(4) // MARK: 임시 값(추후 ConnectionClient에서 받아옴)
     
     private let stickerObjectListSubject = CurrentValueSubject<[StickerEntity], Never>([])
+    private let frameImageSubject = PassthroughSubject<FrameType, Never>()
     
     private var cancellables = Set<AnyCancellable>()
     private var output = PassthroughSubject<Output, Never>()
@@ -34,12 +37,16 @@ public final class EditPhotoRoomHostViewModel {
         frameImageGenerator: FrameImageGenerator,
         fetchEmojiListUseCase: FetchEmojiListUseCase,
         receiveStickerListUseCase: ReceiveStickerListUseCase,
-        sendStickerToRepositoryUseCase: SendStickerToRepositoryUseCase
+        receiveFrameUseCase: ReceiveFrameUseCase,
+        sendStickerToRepositoryUseCase: SendStickerToRepositoryUseCase,
+        sendFrameToRepositoryUseCase: SendFrameToRepositoryUseCase
     ) {
         self.frameImageGenerator = frameImageGenerator
         self.fetchEmojiListUseCase = fetchEmojiListUseCase
         self.receiveStickerListUseCase = receiveStickerListUseCase
+        self.receiveFrameUseCase = receiveFrameUseCase
         self.sendStickerToRepositoryUseCase = sendStickerToRepositoryUseCase
+        self.sendFrameToRepositoryUseCase = sendFrameToRepositoryUseCase
         bind()
     }
     
@@ -52,9 +59,21 @@ public final class EditPhotoRoomHostViewModel {
             }
             .store(in: &cancellables)
         
+        frameImageSubject
+            .sink { [weak self] frameType in
+                
+            }
+            .store(in: &cancellables)
+        
         receiveStickerListUseCase.execute()
             .sink { [weak self] receivedStickerList in
                 self?.stickerObjectListSubject.send(receivedStickerList)
+            }
+            .store(in: &cancellables)
+        
+        receiveFrameUseCase.execute()
+            .sink { [weak self] receivedFrame in
+                
             }
             .store(in: &cancellables)
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/FrameImageGenerator/FrameImageGenerator.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/FrameImageGenerator/FrameImageGenerator.swift
@@ -1,3 +1,4 @@
+import PhotoGetherDomainInterface
 import UIKit
 
 public protocol FrameImageGenerator {
@@ -39,9 +40,4 @@ public final class FrameImageGeneratorImpl: FrameImageGenerator {
     public func generate() -> UIImage {
         return frameView.render()
     }
-}
-
-public enum FrameType {
-    case defaultBlack
-    case defaultWhite
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
@@ -74,13 +74,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let sendStickerToRepositoryGuestUseCase = SendStickerToRepositoryUseCaseImpl(
             eventConnectionRepository: eventConnectionGuestRepository
         )
-        
+        let sendFrameToRepositoryGuestUseCase = SendFrameToRepositoryUseCaseImpl(
+            eventConnectionRepository: eventConnectionGuestRepository
+        )
+        let sendFrameToRepositoryHostUseCase = SendFrameToRepositoryUseCaseImpl(
+            eventConnectionRepository: eventConnectionHostRepository
+        )
         
         let editPhotoRoomHostViewModel = EditPhotoRoomHostViewModel(
             frameImageGenerator: frameImageGenerator,
             fetchEmojiListUseCase: fetchEmojiListUseCase,
             receiveStickerListUseCase: receiveStickerListHostUseCase,
-            sendStickerToRepositoryUseCase: sendStickerToRepositoryHostUseCase
+            sendStickerToRepositoryUseCase: sendStickerToRepositoryHostUseCase,
+            sendFrameToRepositoryUseCase: sendFrameToRepositoryHostUseCase
         )
         let editPhotoRoomHostViewController = EditPhotoRoomHostViewController(
             viewModel: editPhotoRoomHostViewModel
@@ -90,7 +96,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             frameImageGenerator: frameImageGenerator,
             fetchEmojiListUseCase: fetchEmojiListUseCase,
             receiveStickerListUseCase: receiveStickerListGuestUseCase,
-            sendStickerToRepositoryUseCase: sendStickerToRepositoryGuestUseCase
+            sendStickerToRepositoryUseCase: sendStickerToRepositoryGuestUseCase,
+            sendFrameToRepositoryUseCase: sendFrameToRepositoryGuestUseCase
         )
         
         let editPhotoRoomGuestViewController = EditPhotoRoomGuestViewController(

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
@@ -84,9 +84,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             eventConnectionRepository: eventConnectionHostRepository
         )
         
+        let receiveFrameHostUseCase = ReceiveFrameUseCaseImpl(
+            eventConnectionRepository: eventConnectionHostRepository
+        )
+        let receiveFrameGuestUseCase = ReceiveFrameUseCaseImpl(
+            eventConnectionRepository: eventConnectionGuestRepository
+        )
+        
         let editPhotoRoomHostViewModel = EditPhotoRoomHostViewModel(
             frameImageGenerator: frameImageGenerator,
             receiveStickerListUseCase: receiveStickerListHostUseCase,
+            receiveFrameUseCase: receiveFrameHostUseCase,
             sendStickerToRepositoryUseCase: sendStickerToRepositoryHostUseCase,
             sendFrameToRepositoryUseCase: sendFrameToRepositoryHostUseCase
         )
@@ -107,6 +115,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let editPhotoRoomGuestViewModel = EditPhotoRoomGuestViewModel(
             frameImageGenerator: frameImageGenerator,
             receiveStickerListUseCase: receiveStickerListGuestUseCase,
+            receiveFrameUseCase: receiveFrameGuestUseCase,
             sendStickerToRepositoryUseCase: sendStickerToRepositoryGuestUseCase,
             sendFrameToRepositoryUseCase: sendFrameToRepositoryGuestUseCase
         )

--- a/PhotoGether/PresentationLayer/PhotoRoomFeature/PhotoRoomFeature/Source/ViewController/PhotoRoomViewController.swift
+++ b/PhotoGether/PresentationLayer/PhotoRoomFeature/PhotoRoomFeature/Source/ViewController/PhotoRoomViewController.swift
@@ -129,12 +129,12 @@ public final class PhotoRoomViewController: BaseViewController, ViewControllerCo
                     eventConnectionRepository: eventConnectionRepository
                 )
                 
-                let viewModel = EditPhotoRoomHostViewModel(
-                    frameImageGenerator: frameImageGenerator,
-                    fetchEmojiListUseCase: fetchEmojiListUseCase,
-                    receiveStickerListUseCase: receiveStickerListUseCase,
-                    sendStickerToRepositoryUseCase: sendStickerToRepositoryUseCase
-                )
+//                let viewModel = EditPhotoRoomHostViewModel(
+//                    frameImageGenerator: frameImageGenerator,
+//                    fetchEmojiListUseCase: fetchEmojiListUseCase,
+//                    receiveStickerListUseCase: receiveStickerListUseCase,
+//                    sendStickerToRepositoryUseCase: sendStickerToRepositoryUseCase
+//                )
                 
 //                let viewController = EditPhotoRoomHostViewController(viewModel: viewModel)
                 let viewController = UIViewController()


### PR DESCRIPTION
## 🤔 배경
기존 `EventEntity`는 `StickerEntity`만을 `payload`로 담아 통신하는 구조였습니다.
`Host`, `Guest` 간에 `FrameEntity` 또한 브로드캐스팅 되어야하기 때문에 이를 개선해야 했습니다.

따라서 `FrameEntity`를 구현하고, 관련 `EventHub`의 로직을 구현 및 리팩터링이 이뤄졌으며, `WebRTC` 통신과정에서 `Decoding/Encoding` 과정을 단순화하고자 `EventPayload`의 연관값과 분기를 활용했습니다.

비즈니스로직을 `View`의 `UIControl Event`와 연동하고자 의존성 주입을 시도하였으나 기존 코드의 많은 개선이 필요하여
`화면 관련 UI 작업`은 너무 길어져서 `추후 PR`로 남기겠습니다.

네이밍의 경우 최대한 신경썻지만 이상한 부분은 영훈님과 논의하지 않은 부분이라 임시로 처리되어 있습니다.
`ex. sendToViewModel, sendToViewModelFrame` 등

...PR 고봉밥 죄송합니다.. 리뷰노트만 확인해주시고 커밋단위로 훑어보는 정도면 크게 어렵지 않습니다..!

## 📃 작업 내역
- `FrameEntity 및 FrameType`: 프레임 데이터 관리를 위해 추가 구현
- `EventPayload 구현`: `EventHub` 및 통신에서 `Sticker`와 `Frame` 데이터를 통합적으로 처리합니다.
- `EventManager 분리`: `EventHub`에서 `Sticker`와 `Frame` 이벤트를 각각의 매니저로 분리하여 관리할 수 있도록 리팩터링
- `EventHub 리팩터링`: `FrameManger`가 추가되어 큐 상태와 매니저의 상태를 기반으로 이벤트 처리를 리팩터링
- 통신 과정의 데이터 구조 개선: 단순 `Data`가 아닌 `EventPayload` 타입과 연관값을 활용한 데이터 전송 및 분기 로직을 단순화
- 관련 `UseCase`, `Repository` 추가 및 `의존성 주입`

## ✅ 리뷰 노트
### 폴더링 관련
- `EventHub` 내의 클래스 및 파일 분리는 컨플릭트를 고려하여 추후 진행할 예정입니다.

### FrameEventManager 구현
- 프레임변경의 경우 단발성 이벤트이므로 소유권과 관계 없이 누구나 갱신할 수 있도록 하였습니다.
- `EventType`으로 `.update`만을 사용합니다.
- `EventHub 중앙 집중`을 위해 반드시 이를 거치도록 구현했습니다.
```swift
// FrameEventManager.swift
    private func updateEvent(by frame: FrameEntity) {
        guard currentFrame?.frameType != frame.frameType else { return }
        currentFrame = frame
        broadcastSubject.send(frame)
    }
```
- 의도치 않은 이벤트가 들어온다면 이전 상태를 갱신하기 위해 `currentFrame`을 갖습니다.
```swift
    private var currentFrame: FrameEntity?

    ...

    func work(type: EventType, with frame: FrameEntity) {
        isReadySubject.send(false)
        switch type {
        case .update:
            updateEvent(by: frame)
        default:
            debugPrint("DEBUG: 의도치 않은 상황에서 모든 참여자 전체 갱신")
            broadcastSubject.send(frame)
        }
        isReadySubject.send(true)
    }
```
### EventHub의 EventManager 분리
```swift
    private func bind() {
        eventQueue.isEmptyPublisher
            .combineLatest(stickerEventManager.isReady, frameEventManager.isReady)
            .filter { $0 && ($1 || $2) } // MARK: (큐에 내보낼 이벤트가 있음) && (스티커 매니저가 준비됨 || 프레임 매니저가 준비됨) -> 보낸다
            .map { ($1, $2) }
            .sink { [weak self] isStickerReady, isFrameReady in
                self?.processEvent(isStickerReady: isStickerReady, isFrameReady: isFrameReady)
            }
            .store(in: &cancellables)
    }
    
    private func processEvent(isStickerReady: Bool, isFrameReady: Bool) {
        // 큐에서 내보낼 이벤트의 페이로드 타입
        guard let payloadType = eventQueue.lastEventPayload() else { return }
        
        // 페이로드 타입과 준비 상태가 일치해야함
        guard isPayloadTypeReady(type: payloadType, isStickerReady: isStickerReady, isFrameReady: isFrameReady) else { return }
        
        // 이벤트 큐에서 꺼내기
        guard let currentEvent = eventQueue.popLast() else { return }

        handleEvent(currentEvent, isStickerReady: isStickerReady, isFrameReady: isFrameReady)
    }

    private func isPayloadTypeReady(type: EventPayload, isStickerReady: Bool, isFrameReady: Bool) -> Bool {
        switch type {
        case .sticker:
            return isStickerReady
        case .frame:
            return isFrameReady
        default:
            return false
        }
    }

    private func handleEvent(_ event: EventEntity, isStickerReady: Bool, isFrameReady: Bool) {
        switch event.payload {
        case .sticker(let stickerEntity) where isStickerReady:
            stickerEventManager.work(type: event.type, with: stickerEntity)
        case .frame(let frameEntity) where isFrameReady:
            frameEventManager.work(type: event.type, with: frameEntity)
        default:
            debugPrint("handleEvent 에러 - 처리할 수 없는 이벤트")
        }
    }
```
- 기존 `StickerEventManager`만 존재했을 때는 현재 `EventQueue`와 `StickerEventManager`가 준비만 된다면 따로 핸들링이 필요하지 않았습니다.
- 하지만 `FrameEventManager`가 추가되어 부가적인 핸들링이 필요해졌습니다.
- `processEvent`에서 준비된 이벤트큐의 `Event`의 타입이 `Sticker`일때는 `StickerManager`가 준비가 되어야하며 `Frame`일때도 상동합니다.
- 이에 대한 여집합의 경우 `EventQueue`의 `popLast()` 메서드를 호출하면 해당 `EventQueue`에서 `Event가` 방출되며 처리되지 않고 리턴되기 때문에 아래와 같은 메서드를 `EventQueue`에 추가하였고 `processEvent`에서 처리하고 있습니다.
```swift
final class EventQueue {
    ...

    func lastEventPayload() -> EventPayload? {
        return queue.last?.payload
    }
}
```

### WebRTC sendData() 통신 시 전달할 데이터의 디코딩/인코딩
> 호스트가 sendData하는 경우
```swift
// MARK: HOST
        eventHub.stickerListPublisher
            .sink { [weak self] entityList in
                let payload = EventPayload.stickerList(entityList)
                guard let encodedData = try? self?.encoder.encode(payload) else { return }
                self?.clients.forEach { $0.sendData(data: encodedData)}
               ...
            }
            .store(in: &cancellables)
        
        eventHub.framePublisher
            .sink { [weak self] frameEntity in
                let payload = EventPayload.frame(frameEntity)
                guard let encodedData = try? self?.encoder.encode(payload) else { return }
                self?.clients.forEach { $0.sendData(data: encodedData) }
               ...
            }
            .store(in: &cancellables)
```
- `Host`는 `Guest`들에게 `encoding`된 `Data`를 송신해야하며, 이때 `EventPayload`에 담아 보냅니다.

```swift
// MARK: GUEST
        clients.first?.receivedDataPublisher
            .sink(receiveValue: { [weak self] data in
                guard let payload = try? self?.decoder.decode(EventPayload.self, from: data) else { return }
                
                switch payload {
                case .stickerList(let stickerList):
                    self?.receiveDataFromHost.send(stickerList)
                case .frame(let frameEntity):
                    self?.receiveDataFromHostFrame.send(frameEntity)
                default:
                    break
                }
            })
            .store(in: &cancellables)
```
- `Guest`의 경우 해당 `sendData()`로 송신한 데이터를 `receivedDataPublisher`를 통해 수신하며, 이때 `EventPayload`로 `단 1회 디코딩`합니다.
- `EventPayload` 및 연관값으로 감싸지않고 분기를 통해 각 `[StickerEntity].self`와 `FrameEntity.self`로 디코딩을 하는 경우 불필요한 디코딩 및 실패가 일어날 수 있어 이 방식을 채택하였습니다.

## 🎨 스크린샷

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/ddc103bb-7c56-4d16-9528-6c65cb386378">

- `UI`를 제외한 `비즈니스로직`만을 구현하였습니다.
- `Guest`의 `receiveDataPublisher`, 해당 데이터의 `EventPayload 디코딩` 및 `Sticker/Frame 엔티티의 분기`를 확인했습니다.


## 🚀 테스트 방법
asyncAfter를 통해 임의로 Event를 EventHub에 push하면 가능하긴 합니다..
