### PR TITLE
[FEAT/#107] 토스트 메시지를 띄울 수 있는 기능을 추가합니다.

### DIFF
--- a/PhotoGether/PresentationLayer/BaseFeature/BaseFeature.xcodeproj/project.pbxproj
+++ b/PhotoGether/PresentationLayer/BaseFeature/BaseFeature.xcodeproj/project.pbxproj
@@ -6,7 +6,27 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		7B20C8172CF59C2A001325DC /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B20C8162CF59C2A001325DC /* DesignSystem.framework */; };
+		7B20C8182CF59C2A001325DC /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B20C8162CF59C2A001325DC /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		7B20C8192CF59C2A001325DC /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				7B20C8182CF59C2A001325DC /* DesignSystem.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		7B20C8162CF59C2A001325DC /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B5951382CDB5E5500B89C85 /* BaseFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BaseFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -23,16 +43,26 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B20C8172CF59C2A001325DC /* DesignSystem.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7B20C8152CF59C2A001325DC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				7B20C8162CF59C2A001325DC /* DesignSystem.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		7B59512E2CDB5E5500B89C85 = {
 			isa = PBXGroup;
 			children = (
 				7B17465C2CE8E97F00E01D1A /* BaseFeature */,
+				7B20C8152CF59C2A001325DC /* Frameworks */,
 				7B5951392CDB5E5500B89C85 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -66,6 +96,7 @@
 				7B5951342CDB5E5500B89C85 /* Sources */,
 				7B5951352CDB5E5500B89C85 /* Frameworks */,
 				7B5951362CDB5E5500B89C85 /* Resources */,
+				7B20C8192CF59C2A001325DC /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/Extension/UIViewController+ShowToast.swift
+++ b/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/Extension/UIViewController+ShowToast.swift
@@ -1,0 +1,59 @@
+import UIKit
+import DesignSystem
+
+public extension UIViewController {
+    func showToast(message: String, duration: TimeInterval = 2.0) {
+        let padding = UIEdgeInsets(top: 8, left: 20, bottom: 8, right: 20)
+        let toastLabel: PTGPaddingLabel = {
+            let lbl = PTGPaddingLabel(padding: padding)
+            lbl.text = message
+            lbl.textColor = .black
+            lbl.backgroundColor = UIColor.white.withAlphaComponent(0.8)
+            lbl.textAlignment = .center
+            lbl.font = UIFont.systemFont(ofSize: 12, weight: .medium)
+            lbl.numberOfLines = 1
+            lbl.lineBreakMode = .byTruncatingTail
+            lbl.setKern()
+            lbl.layer.cornerRadius = 17.5
+            lbl.layer.shadowOpacity = 0.25
+            lbl.layer.shadowColor = UIColor.black.cgColor
+            lbl.layer.shadowOffset = CGSize(width: 4, height: 4)
+            lbl.clipsToBounds = true
+            return lbl
+        }()
+
+        view.addSubview(toastLabel)
+        
+        let maxWidth: CGFloat = view.frame.width > 0 ? view.frame.width * 0.7 : 300
+
+        toastLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(20)
+            $0.centerX.equalToSuperview()
+            $0.width.lessThanOrEqualTo(maxWidth)
+            $0.height.equalTo(35)
+        }
+        
+        toastLabel.transform = CGAffineTransform(translationX: 0, y: -30)
+        toastLabel.alpha = 0
+                
+        // 보여지는 애니메이션
+        let showAnimator = UIViewPropertyAnimator(duration: 0.3, curve: .easeInOut) {
+            toastLabel.transform = .identity
+            toastLabel.alpha = 1
+        }
+        
+        showAnimator.startAnimation()
+        
+        showAnimator.addCompletion { _ in
+            // 사라지는 애니메이션
+            let hideAnimator = UIViewPropertyAnimator(duration: 0.3, curve: .easeInOut) {
+                toastLabel.transform = CGAffineTransform(translationX: 0, y: -30)
+                toastLabel.alpha = 0
+            }
+            hideAnimator.startAnimation(afterDelay: duration)
+            hideAnimator.addCompletion { _ in
+                toastLabel.removeFromSuperview()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 배경
에러나 사용자 액션에 대한 반응이 없으면 사용자 경험에 악영향을 끼치기 때문에, 간단하게 토스트 메시지라도 띄울 수 있도록 했습니다.

## 📃 작업 내역
- BaseFeature가 DesignSystem을 의존하도록 합니다.
- BaseFeature에 UIViewController Extension 메소드로 `showToast(message:, duration:)` 을 추가합니다.

## ✅ 리뷰 노트


## 🎨 스크린샷

### 최대 Width 는 뷰 프레임의 0.7배로 설정

<img src="https://github.com/user-attachments/assets/4b8f69a8-f4b5-45a2-833d-be6ba763f59f" width="50%">


<img src="https://github.com/user-attachments/assets/29ee9f95-ca2f-4900-bd0a-8b36aa2defad" width="50%">




## 🚀 테스트 방법
`BaseFeature`를 import한 후, ViewController 내에서 `showToast(message: )` 메소드를 호출하면 됩니다.
