### PR TITLE
[FEAT/#108] 프레임 버튼과 이벤트 허브의 비즈니스 로직을 연동합니다

### DIFF
--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
@@ -41,6 +41,7 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
         configureUI()
         bindInput()
         bindOutput()
+        viewModel.configureDefaultState()
     }
     
     public func addViews() {
@@ -109,8 +110,6 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
             }
         }
         .store(in: &cancellables)
-        
-        viewModel.setupFrame()
     }
     
     private func updateFrameImage(to image: UIImage) {

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -163,7 +163,11 @@ extension EditPhotoRoomGuestViewModel {
         let frameEntity = FrameEntity(frameType: frameType, owner: owner, latestUpdated: Date())
         sendFrameToRepositoryUseCase.execute(type: .update, frame: frameEntity)
     }
+
+    private func applyFrameImage(with frameType: FrameType) {
+        frameImageGenerator.changeFrame(to: frameType)
         let frameImage = frameImageGenerator.generate()
+
         output.send(.frameImage(image: frameImage))
     }
     

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -86,7 +86,7 @@ public final class EditPhotoRoomGuestViewModel {
                 self?.appendSticker(with: sticker)
                 self?.sendToRepository(type: .create, with: sticker)
             case .frameButtonDidTap:
-                self?.toggleFrameImage()
+                self?.toggleFrameType()
             case .stickerViewDidTap(let stickerID):
                 self?.handleStickerViewDidTap(with: stickerID)
             }
@@ -131,21 +131,6 @@ public final class EditPhotoRoomGuestViewModel {
         }
     }
     
-    private func toggleFrameImage() {
-        let currentFrameImageType = frameImageGenerator.frameType
-        var newFrameImageType: FrameType
-        switch currentFrameImageType {
-        case .defaultBlack:
-            newFrameImageType = .defaultWhite
-        case .defaultWhite:
-            newFrameImageType = .defaultBlack
-        }
-        
-        frameImageGenerator.changeFrame(to: newFrameImageType)
-        let newFrameImage = frameImageGenerator.generate()
-        output.send(.frameImage(image: newFrameImage))
-    }
-    
     private func appendSticker(with sticker: StickerEntity) {
         var currentStickerObjectList = stickerObjectListSubject.value
         currentStickerObjectList.append(sticker)
@@ -157,6 +142,15 @@ public final class EditPhotoRoomGuestViewModel {
     }
     
     func setupFrame() {
+    private func toggleFrameType() {
+        let oldFrameImageType = frameTypeSubject.value
+        let newFrameImageType = (oldFrameImageType == .defaultBlack)
+        ? FrameType.defaultWhite
+        : FrameType.defaultBlack
+
+        mutateFrameTypeLocal(with: newFrameImageType)
+        mutateFrameTypeEventHub(with: newFrameImageType)
+    }
         let frameImage = frameImageGenerator.generate()
         output.send(.frameImage(image: frameImage))
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -46,6 +46,11 @@ public final class EditPhotoRoomGuestViewModel {
         bind()
     }
     
+    func configureDefaultState() {
+        let defaultFrameType = Constants.defaultFrameType
+        mutateFrameTypeLocal(with: defaultFrameType)
+    }
+    
     private func bind() {
         stickerObjectListSubject
             .sink { [weak self] list in

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -142,6 +142,7 @@ public final class EditPhotoRoomGuestViewModel {
     }
     
     func setupFrame() {
+extension EditPhotoRoomGuestViewModel {
     private func toggleFrameType() {
         let oldFrameImageType = frameTypeSubject.value
         let newFrameImageType = (oldFrameImageType == .defaultBlack)
@@ -150,6 +151,15 @@ public final class EditPhotoRoomGuestViewModel {
 
         mutateFrameTypeLocal(with: newFrameImageType)
         mutateFrameTypeEventHub(with: newFrameImageType)
+    }
+
+    private func mutateFrameTypeLocal(with frameType: FrameType) {
+        frameTypeSubject.send(frameType)
+    }
+
+    private func mutateFrameTypeEventHub(with frameType: FrameType) {
+        let frameEntity = FrameEntity(frameType: frameType, owner: owner, latestUpdated: Date())
+        sendFrameToRepositoryUseCase.execute(type: .update, frame: frameEntity)
     }
         let frameImage = frameImageGenerator.generate()
         output.send(.frameImage(image: frameImage))

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -97,7 +97,10 @@ public final class EditPhotoRoomGuestViewModel {
         
         return output.eraseToAnyPublisher()
     }
-    
+}
+
+// MARK: Sticker 관련
+extension EditPhotoRoomGuestViewModel {
     private func handleStickerViewDidTap(with stickerID: UUID) {
         // MARK: 선택할 수 있는 객체인지 확인함
         guard canInteractWithSticker(id: stickerID) else { return }
@@ -148,6 +151,7 @@ public final class EditPhotoRoomGuestViewModel {
     }
 }
 
+// MARK: Frame 관련
 extension EditPhotoRoomGuestViewModel {
     private func toggleFrameType() {
         let oldFrameImageType = frameTypeSubject.value

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -59,8 +59,9 @@ public final class EditPhotoRoomGuestViewModel {
             .store(in: &cancellables)
         
         frameTypeSubject
+            .receive(on: RunLoop.main)
             .sink { [weak self] frameType in
-                
+                self?.applyFrameImage(with: frameType)
             }
             .store(in: &cancellables)
         
@@ -72,7 +73,8 @@ public final class EditPhotoRoomGuestViewModel {
 
         receiveFrameUseCase.execute()
             .sink { [weak self] receivedFrame in
-                
+                let receivedFrameType = receivedFrame.frameType
+                self?.frameTypeSubject.send(receivedFrameType)
             }
             .store(in: &cancellables)
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -173,5 +173,8 @@ extension EditPhotoRoomGuestViewModel {
     
     private func presentStickerBottomSheet() {
         output.send(.stickerBottomSheetPresent)
+private extension EditPhotoRoomGuestViewModel {
+    enum Constants {
+        static let defaultFrameType: FrameType = .defaultBlack
     }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -143,7 +143,11 @@ public final class EditPhotoRoomGuestViewModel {
         sendStickerToRepositoryUseCase.execute(type: type, sticker: sticker)
     }
     
-    func setupFrame() {
+    private func presentStickerBottomSheet() {
+        output.send(.stickerBottomSheetPresent)
+    }
+}
+
 extension EditPhotoRoomGuestViewModel {
     private func toggleFrameType() {
         let oldFrameImageType = frameTypeSubject.value
@@ -170,9 +174,8 @@ extension EditPhotoRoomGuestViewModel {
 
         output.send(.frameImage(image: frameImage))
     }
-    
-    private func presentStickerBottomSheet() {
-        output.send(.stickerBottomSheetPresent)
+}
+
 private extension EditPhotoRoomGuestViewModel {
     enum Constants {
         static let defaultFrameType: FrameType = .defaultBlack

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -23,11 +23,10 @@ public final class EditPhotoRoomGuestViewModel {
     private let sendStickerToRepositoryUseCase: SendStickerToRepositoryUseCase
     private let sendFrameToRepositoryUseCase: SendFrameToRepositoryUseCase
     
-
     private let owner = "GUEST" + UUID().uuidString.prefix(4) // MARK: 임시 값(추후 ConnectionClient에서 받아옴)
     
     private let stickerObjectListSubject = CurrentValueSubject<[StickerEntity], Never>([])
-    private let frameImageSubject = PassthroughSubject<FrameType, Never>()
+    private let frameTypeSubject = CurrentValueSubject<FrameType, Never>(Constants.defaultFrameType)
     
     private var cancellables = Set<AnyCancellable>()
     private var output = PassthroughSubject<Output, Never>()
@@ -54,7 +53,7 @@ public final class EditPhotoRoomGuestViewModel {
             }
             .store(in: &cancellables)
         
-        frameImageSubject
+        frameTypeSubject
             .sink { [weak self] frameType in
                 
             }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -67,14 +67,14 @@ public final class EditPhotoRoomGuestViewModel {
         
         receiveStickerListUseCase.execute()
             .sink { [weak self] receivedStickerList in
-                self?.stickerListSubject.send(receivedStickerList)
+                self?.mutateStickerListLocal(stickerList: receivedStickerList)
             }
             .store(in: &cancellables)
 
         receiveFrameUseCase.execute()
             .sink { [weak self] receivedFrame in
                 let receivedFrameType = receivedFrame.frameType
-                self?.frameTypeSubject.send(receivedFrameType)
+                self?.mutateFrameTypeLocal(with: receivedFrameType)
             }
             .store(in: &cancellables)
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -41,6 +41,7 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
         configureUI()
         bindInput()
         bindOutput()
+        viewModel.configureDefaultState()
     }
     
     public func addViews() {
@@ -135,8 +136,6 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
                 }
             }
             .store(in: &cancellables)
-        
-        viewModel.setupFrame()
     }
 
     private func updateFrameImage(to image: UIImage) {

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -174,5 +174,8 @@ extension EditPhotoRoomHostViewModel {
     
     private func presentStickerBottomSheet() {
         output.send(.presentStickerBottomSheet)
+private extension EditPhotoRoomHostViewModel {
+    enum Constants {
+        static let defaultFrameType: FrameType = .defaultBlack
     }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -87,7 +87,7 @@ public final class EditPhotoRoomHostViewModel {
                 self?.appendSticker(with: sticker)
                 self?.sendToRepository(type: .create, with: sticker)
             case .frameButtonDidTap:
-                self?.toggleFrameImage()
+                self?.toggleFrameType()
             case .stickerViewDidTap(let stickerID):
                 self?.handleStickerViewDidTap(with: stickerID)
             }
@@ -132,21 +132,6 @@ public final class EditPhotoRoomHostViewModel {
         }
     }
     
-    private func toggleFrameImage() {
-        let currentFrameImageType = frameImageGenerator.frameType
-        var newFrameImageType: FrameType
-        switch currentFrameImageType {
-        case .defaultBlack:
-            newFrameImageType = .defaultWhite
-        case .defaultWhite:
-            newFrameImageType = .defaultBlack
-        }
-        
-        frameImageGenerator.changeFrame(to: newFrameImageType)
-        let newFrameImage = frameImageGenerator.generate()
-        output.send(.frameImage(image: newFrameImage))
-    }
-    
     private func appendSticker(with sticker: StickerEntity) {
         var currentStickerObjectList = stickerObjectListSubject.value
         currentStickerObjectList.append(sticker)
@@ -158,6 +143,15 @@ public final class EditPhotoRoomHostViewModel {
     }
     
     func setupFrame() {
+    private func toggleFrameType() {
+        let oldFrameImageType = frameTypeSubject.value
+        let newFrameImageType = (oldFrameImageType == .defaultBlack)
+        ? FrameType.defaultWhite
+        : FrameType.defaultBlack
+        
+        mutateFrameTypeLocal(with: newFrameImageType)
+        mutateFrameTypeEventHub(with: newFrameImageType)
+    }
         let frameImage = frameImageGenerator.generate()
         output.send(.frameImage(image: frameImage))
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -26,7 +26,7 @@ public final class EditPhotoRoomHostViewModel {
     private let owner = "Host" + UUID().uuidString.prefix(4) // MARK: 임시 값(추후 ConnectionClient에서 받아옴)
     
     private let stickerObjectListSubject = CurrentValueSubject<[StickerEntity], Never>([])
-    private let frameImageSubject = PassthroughSubject<FrameType, Never>()
+    private let frameTypeSubject = CurrentValueSubject<FrameType, Never>(Constants.defaultFrameType)
     
     private var cancellables = Set<AnyCancellable>()
     private var output = PassthroughSubject<Output, Never>()
@@ -53,7 +53,7 @@ public final class EditPhotoRoomHostViewModel {
             }
             .store(in: &cancellables)
         
-        frameImageSubject
+        frameTypeSubject
             .sink { [weak self] frameType in
                 
             }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -143,6 +143,7 @@ public final class EditPhotoRoomHostViewModel {
     }
     
     func setupFrame() {
+extension EditPhotoRoomHostViewModel {
     private func toggleFrameType() {
         let oldFrameImageType = frameTypeSubject.value
         let newFrameImageType = (oldFrameImageType == .defaultBlack)
@@ -151,6 +152,15 @@ public final class EditPhotoRoomHostViewModel {
         
         mutateFrameTypeLocal(with: newFrameImageType)
         mutateFrameTypeEventHub(with: newFrameImageType)
+    }
+    
+    private func mutateFrameTypeLocal(with frameType: FrameType) {
+        frameTypeSubject.send(frameType)
+    }
+    
+    private func mutateFrameTypeEventHub(with frameType: FrameType) {
+        let frameEntity = FrameEntity(frameType: frameType, owner: owner, latestUpdated: Date())
+        sendFrameToRepositoryUseCase.execute(type: .update, frame: frameEntity)
     }
         let frameImage = frameImageGenerator.generate()
         output.send(.frameImage(image: frameImage))

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -60,8 +60,9 @@ public final class EditPhotoRoomHostViewModel {
             .store(in: &cancellables)
         
         frameTypeSubject
+            .receive(on: RunLoop.main)
             .sink { [weak self] frameType in
-                
+                self?.applyFrameImage(with: frameType)
             }
             .store(in: &cancellables)
         
@@ -73,7 +74,8 @@ public final class EditPhotoRoomHostViewModel {
         
         receiveFrameUseCase.execute()
             .sink { [weak self] receivedFrame in
-                
+                let receivedFrameType = receivedFrame.frameType
+                self?.frameTypeSubject.send(receivedFrameType)
             }
             .store(in: &cancellables)
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -68,14 +68,14 @@ public final class EditPhotoRoomHostViewModel {
         
         receiveStickerListUseCase.execute()
             .sink { [weak self] receivedStickerList in
-                self?.stickerListSubject.send(receivedStickerList)
+                self?.mutateStickerListLocal(stickerList: receivedStickerList)
             }
             .store(in: &cancellables)
         
         receiveFrameUseCase.execute()
             .sink { [weak self] receivedFrame in
                 let receivedFrameType = receivedFrame.frameType
-                self?.frameTypeSubject.send(receivedFrameType)
+                self?.mutateFrameTypeLocal(with: receivedFrameType)
             }
             .store(in: &cancellables)
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -46,6 +46,12 @@ public final class EditPhotoRoomHostViewModel {
         bind()
     }
     
+    func configureDefaultState() {
+        let defaultFrameType = Constants.defaultFrameType
+        mutateFrameTypeLocal(with: defaultFrameType)
+        mutateFrameTypeEventHub(with: defaultFrameType)
+    }
+    
     private func bind() {
         stickerObjectListSubject
             .sink { [weak self] list in

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -86,8 +86,7 @@ public final class EditPhotoRoomHostViewModel {
             case .stickerButtonDidTap:
                 self?.presentStickerBottomSheet()
             case .createSticker(let sticker):
-                self?.appendSticker(with: sticker)
-                self?.sendToRepository(type: .create, with: sticker)
+                self?.handleCreateSticker(sticker: sticker)
             case .frameButtonDidTap:
                 self?.toggleFrameType()
             case .stickerViewDidTap(let stickerID):
@@ -102,6 +101,25 @@ public final class EditPhotoRoomHostViewModel {
 
 // MARK: Sticker 관련
 extension EditPhotoRoomHostViewModel {
+    private func handleCreateSticker(sticker: StickerEntity) {
+        mutateStickerLocal(sticker: sticker)
+        mutateStickerEventHub(type: .create, with: sticker)
+    }
+    
+    private func mutateStickerLocal(sticker: StickerEntity) {
+        var stickerList = stickerListSubject.value
+        stickerList.append(sticker)
+        stickerListSubject.send(stickerList)
+    }
+    
+    private func mutateStickerListLocal(stickerList: [StickerEntity]) {
+        stickerListSubject.send(stickerList)
+    }
+    
+    private func mutateStickerEventHub(type: EventType, with sticker: StickerEntity) {
+        sendStickerToRepositoryUseCase.execute(type: type, sticker: sticker)
+    }
+    
     private func handleStickerViewDidTap(with stickerID: UUID) {
         // MARK: 선택할 수 있는 객체인지 확인함
         guard canInteractWithSticker(id: stickerID) else { return }
@@ -124,7 +142,7 @@ extension EditPhotoRoomHostViewModel {
         
         if let previousSticker = stickerList.lockedSticker(by: owner) {
             stickerList.unlock(by: owner)
-            sendToRepository(type: .unlock, with: previousSticker)
+            mutateStickerEventHub(type: .unlock, with: previousSticker)
         }
     }
     
@@ -132,19 +150,9 @@ extension EditPhotoRoomHostViewModel {
         var stickerList = stickerListSubject.value
         
         if let tappedSticker = stickerList.lock(by: id, owner: owner) {
-            stickerListSubject.send(stickerList)
-            sendToRepository(type: .update, with: tappedSticker)
+            mutateStickerListLocal(stickerList: stickerList)
+            mutateStickerEventHub(type: .update, with: tappedSticker)
         }
-    }
-    
-    private func appendSticker(with sticker: StickerEntity) {
-        var currentStickerObjectList = stickerListSubject.value
-        currentStickerObjectList.append(sticker)
-        stickerListSubject.send(currentStickerObjectList)
-    }
-
-    private func sendToRepository(type: EventType, with sticker: StickerEntity) {
-        sendStickerToRepositoryUseCase.execute(type: type, sticker: sticker)
     }
     
     private func presentStickerBottomSheet() {

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -164,7 +164,11 @@ extension EditPhotoRoomHostViewModel {
         let frameEntity = FrameEntity(frameType: frameType, owner: owner, latestUpdated: Date())
         sendFrameToRepositoryUseCase.execute(type: .update, frame: frameEntity)
     }
+    
+    private func applyFrameImage(with frameType: FrameType) {
+        frameImageGenerator.changeFrame(to: frameType)
         let frameImage = frameImageGenerator.generate()
+        
         output.send(.frameImage(image: frameImage))
     }
     

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -98,7 +98,10 @@ public final class EditPhotoRoomHostViewModel {
         
         return output.eraseToAnyPublisher()
     }
-    
+}
+
+// MARK: Sticker 관련
+extension EditPhotoRoomHostViewModel {
     private func handleStickerViewDidTap(with stickerID: UUID) {
         // MARK: 선택할 수 있는 객체인지 확인함
         guard canInteractWithSticker(id: stickerID) else { return }
@@ -149,6 +152,7 @@ public final class EditPhotoRoomHostViewModel {
     }
 }
 
+// MARK: Frame 관련
 extension EditPhotoRoomHostViewModel {
     private func toggleFrameType() {
         let oldFrameImageType = frameTypeSubject.value

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -144,7 +144,11 @@ public final class EditPhotoRoomHostViewModel {
         sendStickerToRepositoryUseCase.execute(type: type, sticker: sticker)
     }
     
-    func setupFrame() {
+    private func presentStickerBottomSheet() {
+        output.send(.presentStickerBottomSheet)
+    }
+}
+
 extension EditPhotoRoomHostViewModel {
     private func toggleFrameType() {
         let oldFrameImageType = frameTypeSubject.value
@@ -171,9 +175,8 @@ extension EditPhotoRoomHostViewModel {
         
         output.send(.frameImage(image: frameImage))
     }
-    
-    private func presentStickerBottomSheet() {
-        output.send(.presentStickerBottomSheet)
+}
+
 private extension EditPhotoRoomHostViewModel {
     enum Constants {
         static let defaultFrameType: FrameType = .defaultBlack

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
@@ -103,13 +103,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             fetchEmojiListUseCase: fetchEmojiListUseCase
         )
         
-        let stickerBottomSheetViewController = StickerBottomSheetViewController(
+        let stickerBottomSheetGuestViewController = StickerBottomSheetViewController(
+            viewModel: stickerBottomSheetViewModel
+        )
+        
+        let stickerBottomSheetHostViewController = StickerBottomSheetViewController(
             viewModel: stickerBottomSheetViewModel
         )
         
         let editPhotoRoomHostViewController = EditPhotoRoomHostViewController(
             viewModel: editPhotoRoomHostViewModel,
-            bottomSheetViewController: stickerBottomSheetViewController
+            bottomSheetViewController: stickerBottomSheetHostViewController
         )
         
         let editPhotoRoomGuestViewModel = EditPhotoRoomGuestViewModel(
@@ -122,7 +126,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let editPhotoRoomGuestViewController = EditPhotoRoomGuestViewController(
             viewModel: editPhotoRoomGuestViewModel,
-            bottomSheetViewController: stickerBottomSheetViewController
+            bottomSheetViewController: stickerBottomSheetGuestViewController
         )
       
         let offerViewController = OfferTempViewController(

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
@@ -24,22 +24,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let webScoketClient: WebSocketClient = WebSocketClientImpl(url: url)
         let signalingService: SignalingService = SignalingServiceImpl(webSocketClient: webScoketClient)
-        
         let webRTCService: WebRTCService = WebRTCServiceImpl(iceServers: [
-            "stun:stun.l.google.com:19302",
-            "stun:stun1.l.google.com:19302",
-            "stun:stun2.l.google.com:19302",
-            "stun:stun3.l.google.com:19302",
+            "stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302",
+            "stun:stun2.l.google.com:19302", "stun:stun3.l.google.com:19302",
             "stun:stun4.l.google.com:19302"
         ])
         let connectionClient: ConnectionClient = ConnectionClientImpl(
             signalingService: signalingService,
             webRTCService: webRTCService
         )
-        
+
         let repository = ConnectionRepositoryImpl(clients: [connectionClient])
         let offerUseCase = SendOfferUseCaseImpl(repository: repository)
-        
         let localDataSource = LocalShapeDataSourceImpl()
         let remoteDataSource = RemoteShapeDataSourceImpl()
         let shapeRepositoryImpl = ShapeRepositoryImpl(


### PR DESCRIPTION
## 🤔 배경
- `EditPhotoRoom`의 `FrameImage`는 `ViewModel`로부터 바인딩 되어야합니다.
- `Host`의 경우 초기에 `EventHub`에 자신의 상태를 전달해야하며 `브로드캐스팅`이 이뤄집니다. `Guest`는 그렇지 않습니다.
- `Sticker`와 마찬가지로 `Frame`은 `Local`에 `선반영`이 이뤄지고, 이후 `EventHub`에 자신의 변경된 상태를 전달합니다.

## 📃 작업 내역
- `ViewModel` `Frame`관련 `input-output 스트림`의 `가독성 개선`
- `관련 비즈니스 로직` 및 `UI 와 연동`

## ✅ 리뷰 노트
### 초기 Frame 관련 EventHub 업데이트
```swift
// Host
    func configureDefaultState() {
        let defaultFrameType = Constants.defaultFrameType
        mutateFrameTypeLocal(with: defaultFrameType)
        mutateFrameTypeEventHub(with: defaultFrameType)
    }

// Guest
    func configureDefaultState() {
        let defaultFrameType = Constants.defaultFrameType
        mutateFrameTypeLocal(with: defaultFrameType)
    }

    public override func viewDidLoad() {
        super.viewDidLoad()
        
        ...
        bindInput()
        bindOutput()
        viewModel.configureDefaultState()
    }
```
- 호스트가 담당하여 브로드캐스팅을 시도합니다.
- ViewModel을 bind한 후 State를 설정합니다.

### ViewModel에서의 프레임 변경 이벤트 스트림
> 1. 프레임 버튼 탭 이벤트가 들어옵니다.
```swift
func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
    input.sink { [weak self] event in
        switch event {
        case .frameButtonDidTap:
            self?.toggleFrameType()
        // ...
        }
    }
```

>  2. 변경할 FrameType을 설정하고 Local, EventHub으로 스트림을 분기합니다.
```swift
private func toggleFrameType() {
    let oldFrameImageType = frameTypeSubject.value
    let newFrameImageType = (oldFrameImageType == .defaultBlack)
    ? FrameType.defaultWhite
    : FrameType.defaultBlack

    mutateFrameTypeLocal(with: newFrameImageType)
    mutateFrameTypeEventHub(with: newFrameImageType)
}
```

> 3-1.a Local의 경우
```swift
private func mutateFrameTypeLocal(with frameType: FrameType) {
    frameTypeSubject.send(frameType)
}
```
> 3-1-b. Local을 담당하는 frameTypeSubject는 applyFrameImage를 호출합니다.
```swift
frameTypeSubject
        .receive(on: RunLoop.main)
        .sink { [weak self] frameType in
            self?.applyFrameImage(with: frameType)
        }
        .store(in: &cancellables)
```
> 3-1-c. FrameImageGenerator를 통해 frameType에 해당하는 UIImage를 생성하고 output을 전달합니다.
```swift
private func applyFrameImage(with frameType: FrameType) {
    frameImageGenerator.changeFrame(to: frameType)
    let frameImage = frameImageGenerator.generate()

    output.send(.frameImage(image: frameImage))
}
```
> 3-2-a. EventHub의 경우
```swift
private func mutateFrameTypeEventHub(with frameType: FrameType) {
    let frameEntity = FrameEntity(frameType: frameType, owner: owner, latestUpdated: Date())
    sendFrameToRepositoryUseCase.execute(type: .update, frame: frameEntity)
}
```
> 3-2-b. EventConnection~Host로 sendData ~ EventHub를 거쳐 다시 브로드캐스팅을 받아와서 로컬 담당에 전달
```swift
receiveFrameUseCase.execute()
        .sink { [weak self] receivedFrame in
            let receivedFrameType = receivedFrame.frameType
            self?.frameTypeSubject.send(receivedFrameType)
        }
        .store(in: &cancellables)
```
> 3-2-c. 3-1.b~c와 동일한 로직으로 ViewController에게 output으로 전달됨
```swift
frameTypeSubject
        .receive(on: RunLoop.main)
        .sink { [weak self] frameType in
            self?.applyFrameImage(with: frameType)
        }
        .store(in: &cancellables)

private func applyFrameImage(with frameType: FrameType) {
    frameImageGenerator.changeFrame(to: frameType)
    let frameImage = frameImageGenerator.generate()

    output.send(.frameImage(image: frameImage))
}
```

### 가독성 개선 및 mutate 접두어
```swift
        receiveStickerListUseCase.execute()
            .sink { [weak self] receivedStickerList in
                self?.mutateStickerListLocal(stickerList: receivedStickerList)
            }
            .store(in: &cancellables)
    ...        
        receiveFrameUseCase.execute()
            .sink { [weak self] receivedFrame in
                let receivedFrameType = receivedFrame.frameType
                self?.mutateFrameTypeLocal(with: receivedFrameType)
            }
            .store(in: &cancellables)
    ...
    private func lockTappedSticker(id: UUID) {
        var stickerList = stickerListSubject.value
        
        if let tappedSticker = stickerList.lock(by: id, owner: owner) {
            mutateStickerListLocal(stickerList: stickerList)
            mutateStickerEventHub(type: .update, with: tappedSticker)
        }
    }
```
- 이외에도 복잡한 코드들이 많습니다. 
- Local에 선반영되는 시점과 EventHub로 전달되는 useCase를 호출하는 부분을 `mutate` 접두어를 통해 명시적으로 두어 가독성을 개선했습니다.

## 🎨 스크린샷
| iPhone SE(3세대) + iPhone 16 |
| -------------------------|
| ![Nov-26-2024 18-14-01](https://github.com/user-attachments/assets/77d4748a-e165-48ee-bb41-edd2734c00d6) |

## 🚀 테스트 방법
- EditPhotoRoomFeatureDemo 실행 후 Host, Guest를 나눠서 테스팅
