### PR TITLE
[FEAT/#112] 이미지 캐시를 구현하고, 비동기 이미지 설정 메소드에 적용합니다.

### DIFF
--- a/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/Extension/UIImageView+SetAsyncImage.swift
+++ b/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/Extension/UIImageView+SetAsyncImage.swift
@@ -3,19 +3,29 @@ import UIKit
 public extension UIImageView {
     @MainActor
     func setAsyncImage(_ url: URL) async {
-        do {
-            let (data, response) = try await URLSession.shared.data(from: url)
-            guard
-                let httpURLResponse = response as? HTTPURLResponse, httpURLResponse.statusCode == 200,
-                let image = UIImage(data: data)
-            else {
-                debugPrint("이미지 다운로드 실패: \(url)")
+        let cachedImage = ImageCache.readCache(with: url)
+        if cachedImage == nil { // MARK: 캐시 히트에 실패한 경우
+            do {
+                let (data, response) = try await URLSession.shared.data(from: url)
+                guard
+                    let httpURLResponse = response as? HTTPURLResponse, httpURLResponse.statusCode == 200,
+                    let image = UIImage(data: data)
+                else {
+                    debugPrint("이미지 다운로드 실패: \(url)")
+                    return
+                }
+                self.image = image
+                
+            } catch {
+                debugPrint("이미지 다운로드 중 오류 발생: \(error.localizedDescription)")
+            }
+        } else { // MARK: 캐시 히트
+            guard let cachedUIImage = UIImage(data: cachedImage!.imageData) else {
+                debugPrint("캐싱이미지 변환에 실패했습니다. \(url)")
                 return
             }
-            self.image = image
             
-        } catch {
-            debugPrint("이미지 다운로드 중 오류 발생: \(error.localizedDescription)")
+            self.image = cachedUIImage
         }
     }
 }

--- a/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/Extension/UIImageView+SetAsyncImage.swift
+++ b/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/Extension/UIImageView+SetAsyncImage.swift
@@ -3,8 +3,13 @@ import UIKit
 public extension UIImageView {
     @MainActor
     func setAsyncImage(_ url: URL) async {
-        let cachedImage = ImageCache.readCache(with: url)
-        if cachedImage == nil { // MARK: 캐시 히트에 실패한 경우
+        if let cachedImage = ImageCache.readCache(with: url) { // MARK: 캐시 히트
+            guard let cachedUIImage = UIImage(data: cachedImage.imageData) else {
+                debugPrint("캐싱이미지 변환에 실패했습니다. \(url)")
+                return
+            }
+            self.image = cachedUIImage
+        } else { // MARK: 캐시 히트에 실패한 경우
             do {
                 let (data, response) = try await URLSession.shared.data(from: url)
                 guard
@@ -23,13 +28,6 @@ public extension UIImageView {
             } catch {
                 debugPrint("이미지 다운로드 중 오류 발생: \(error.localizedDescription)")
             }
-        } else { // MARK: 캐시 히트
-            guard let cachedUIImage = UIImage(data: cachedImage!.imageData) else {
-                debugPrint("캐싱이미지 변환에 실패했습니다. \(url)")
-                return
-            }
-            
-            self.image = cachedUIImage
         }
     }
 }

--- a/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/Extension/UIImageView+SetAsyncImage.swift
+++ b/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/Extension/UIImageView+SetAsyncImage.swift
@@ -14,6 +14,10 @@ public extension UIImageView {
                     debugPrint("이미지 다운로드 실패: \(url)")
                     return
                 }
+                
+                let cachingImage = CacheableImage(imageData: data)
+                ImageCache.updateCache(with: url, image: cachingImage)
+                
                 self.image = image
                 
             } catch {

--- a/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/ImageCache/CacheableImage.swift
+++ b/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/ImageCache/CacheableImage.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public final class CacheableImage: Codable {
+    let imageData: Data
+    
+    public init(imageData: Data) {
+        self.imageData = imageData
+    }
+}

--- a/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/ImageCache/ImageCache.swift
+++ b/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/ImageCache/ImageCache.swift
@@ -1,0 +1,78 @@
+import UIKit
+
+public enum ImageCache {
+    private static let memoryCache: NSCache<NSString, CacheableImage> = {
+        let memoryCache = NSCache<NSString, CacheableImage>()
+        memoryCache.totalCostLimit = 1024 * 1024 * 50 // MARK: 메모리 캐시 최대 용량 50MB
+        return memoryCache
+    }()
+    
+    private static let diskCache: ImageDiskCache = {
+        let diskCache = ImageDiskCache()
+        return diskCache
+    }()
+    
+    /// 메모리 캐시의 최대 용량을 설정합니다.
+    public static func setMaximumMemoryCache(with maximumBytes: Int) {
+        self.memoryCache.totalCostLimit = maximumBytes
+    }
+    
+    public static func readCache(with imageURL: URL) -> CacheableImage? {
+        let imageURLStr = imageURL.absoluteString as NSString
+        
+        if let memoryCachedImage = memoryCache.object(forKey: imageURLStr) {
+            return memoryCachedImage
+        } else {
+            guard let diskCachedImage = diskCache.readCache(with: imageURL) else { return nil }
+            memoryCache.setObject(diskCachedImage, forKey: imageURLStr)
+            return diskCachedImage
+        }
+    }
+    
+    public static func updateCache(with imageURL: URL, image: CacheableImage) {
+        let key = imageURL.absoluteString as NSString
+        memoryCache.setObject(image, forKey: key)
+        diskCache.updateCache(with: imageURL, image: image)
+    }
+    
+    public static func removeCache() {
+        memoryCache.removeAllObjects()
+        diskCache.removeCache()
+    }
+    
+}
+
+public class DiskCache<K, V> where K: NSString, V: Codable {
+    let fileManager = FileManager.default
+    let cacheDirectoryPath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+}
+
+public final class ImageDiskCache: DiskCache<NSString, CacheableImage> {
+    public func readCache(with imageURL: URL) -> CacheableImage? {
+        guard let path = super.cacheDirectoryPath else { return nil }
+        let filePath = path.appendingPathComponent(imageURL.pathComponents.joined(separator: "-"))
+        
+        if fileManager.fileExists(atPath: filePath.path) {
+            guard let imageData = try? Data(contentsOf: filePath) else { return nil }
+            return CacheableImage(imageData: imageData)
+        }
+        return nil
+    }
+    
+    public func updateCache(with imageURL: URL, image: CacheableImage) {
+        guard let path = super.cacheDirectoryPath else { return }
+        let filePath = path.appendingPathComponent(imageURL.pathComponents.joined(separator: "-"))
+        
+        fileManager.createFile(atPath: filePath.path, contents: image.imageData)
+    }
+    
+    public func removeCache() {
+        guard let path = super.cacheDirectoryPath else { return }
+        guard let files = try? fileManager.contentsOfDirectory(atPath: path.path) else { return }
+        
+        files.forEach {
+            let filePath = path.appendingPathComponent($0)
+            try? fileManager.removeItem(at: filePath)
+        }
+    }
+}


### PR DESCRIPTION
## 🤔 배경
스티커 이모지를 네트워킹을 통해 비동기로 불러오는데, 네트워크 환경에 따라 불러오는 속도가 느려 사용자 경험이 좋지 않았습니다.

## 📃 작업 내역
- 이미지 캐시 구현
NSCache를 활용해 메모리 캐시를 구현합니다.
FileManager를 통해 Image를 Data로 변환해 저장합니다. 

#### 캐싱 방식
1. 해당 url에 해당하는 캐시을 요청합니다.
```swift
let cachedImage = ImageCache.readCache(with: url)
```
2-1. 먼저 메모리 캐시에서 찾고, 없으면 디스크 캐시에서 찾아 메모리 캐시를 업데이트한 후 이미지를 리턴합니다.
```swift
public static func readCache(with imageURL: URL) -> CacheableImage? {
        let imageURLStr = imageURL.absoluteString as NSString

        if let memoryCachedImage = memoryCache.object(forKey: imageURLStr) {
            return memoryCachedImage
        } else {
            guard let diskCachedImage = diskCache.readCache(with: imageURL) else { return nil }
            memoryCache.setObject(diskCachedImage, forKey: imageURLStr)
            return diskCachedImage
        }
    }
```
2-2. 캐시 히트에 실패한 경우,  네트워크 요청을 통해 이미지를 가져오고 메모리 캐시와 디스크 캐시를 업데이트하고 이미지를 설정합니다.

```swift
// UIImageView+SetAsyncImage.swift
let (data, response) = try await URLSession.shared.data(from: url)
...
let cachingImage = CacheableImage(imageData: data)
ImageCache.updateCache(with: url, image: cachingImage)
...           
self.image = image

// ImageCache.swift
public static func updateCache(with imageURL: URL, image: CacheableImage) {
        let key = imageURL.absoluteString as NSString
        memoryCache.setObject(image, forKey: key)
        diskCache.updateCache(with: imageURL, image: image)
    }
```


## ✅ 리뷰 노트
빠르게 구현한거라 가독성이 좋지 않습니다🥲
