### PR TITLE
[FEAT/#103] API 데이터 캐싱

### DIFF
--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Disk/CacheManager.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Disk/CacheManager.swift
@@ -1,0 +1,57 @@
+import Combine
+import OSLog
+import UIKit
+
+final class CacheManager {
+    private let fileManager: FileManager
+    private let cacheDirectory: URL
+    
+    init() {
+        self.fileManager = .default
+        self.cacheDirectory = fileManager
+            .urls(for: .cachesDirectory, in: .userDomainMask)
+            .first!
+    }
+    
+    /// 데이터 캐싱
+    ///
+    /// key(URL String)와 data를 Disk cache에 저장
+    /// key의 hash값을 path로 설정하여 중복 방지
+    func save(key: String, data: Data) {
+        let fileURL = cacheDirectory.appendingPathComponent(key.hashValue.description)
+        
+        do { try data.write(to: fileURL) }
+        catch { os_log("ERROR: Failed to save data to disk\n\(error.localizedDescription)") }
+    }
+    
+    /// 캐시 데이터 불러오기
+    ///
+    /// key(URL String)을 기반으로 캐시 메모리를 탐색하여 Data?를 반환
+    func load(key: String) -> Data? {
+        let fileURL = cacheDirectory.appendingPathComponent(key.hashValue.description)
+        
+        return try? Data(contentsOf: fileURL)
+    }
+    
+    /// 캐시 데이터 불러오기
+    ///
+    /// key(URL String)을 기반으로 캐시 메모리를 탐색하여 AnyPublisher<Data?, Error>를 반환
+    func loadPublisher(key: String) -> AnyPublisher<Data?, Error> {
+        let fileURL = cacheDirectory.appendingPathComponent(key.hashValue.description)
+        
+        return Future<Data?, Error> { promise in
+            do {
+                let data = try Data(contentsOf: fileURL)
+                print("DEBUG: Loaded data from disk")
+                promise(.success(data))
+            } catch {
+                promise(.failure(error))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}
+
+extension CacheManager {
+    static let emoji = "emoji"
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Disk/CacheManager.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Disk/CacheManager.swift
@@ -4,7 +4,7 @@ import OSLog
 import UIKit
 
 final class CacheManager {
-private let fileManager: FileManager
+    private let fileManager: FileManager
     private let cacheDirectory: URL
     
     init(path: String) {

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Disk/CacheManager.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Disk/CacheManager.swift
@@ -70,5 +70,7 @@ final class CacheManager {
 }
 
 extension CacheManager {
-    static let emojiPath = "emoji"
+    enum Path {
+        static let emoji = "emoji"
+    }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Disk/CacheManager.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Disk/CacheManager.swift
@@ -4,14 +4,15 @@ import OSLog
 import UIKit
 
 final class CacheManager {
-    private let fileManager: FileManager
+private let fileManager: FileManager
     private let cacheDirectory: URL
     
-    init() {
+    init(path: String) {
         self.fileManager = .default
         self.cacheDirectory = fileManager
             .urls(for: .cachesDirectory, in: .userDomainMask)
             .first!
+            .appendingPathComponent(path)
     }
     
     /// 데이터 캐싱
@@ -62,5 +63,5 @@ final class CacheManager {
 }
 
 extension CacheManager {
-    static let emoji = "emoji"
+    static let emojiPath = "emoji"
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Disk/CacheManager.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Disk/CacheManager.swift
@@ -1,4 +1,5 @@
 import Combine
+import CryptoKit
 import OSLog
 import UIKit
 
@@ -17,8 +18,6 @@ final class CacheManager {
     ///
     /// key(URL String)와 data를 Disk cache에 저장
     /// key의 hash값을 path로 설정하여 중복 방지
-    func save(key: String, data: Data) {
-        let fileURL = cacheDirectory.appendingPathComponent(key.hashValue.description)
         
         do { try data.write(to: fileURL) }
         catch { os_log("ERROR: Failed to save data to disk\n\(error.localizedDescription)") }
@@ -31,13 +30,17 @@ final class CacheManager {
         let fileURL = cacheDirectory.appendingPathComponent(key.hashValue.description)
         
         return try? Data(contentsOf: fileURL)
+    func save(url: URL, data: Data) {
+        let key = hashKey(from: url)
+        let fileURL = cacheDirectory.appendingPathComponent(key)
     }
     
     /// 캐시 데이터 불러오기
     ///
     /// key(URL String)을 기반으로 캐시 메모리를 탐색하여 AnyPublisher<Data?, Error>를 반환
-    func loadPublisher(key: String) -> AnyPublisher<Data?, Error> {
-        let fileURL = cacheDirectory.appendingPathComponent(key.hashValue.description)
+    func loadPublisher(url: URL) -> AnyPublisher<Data?, Error> {
+        let key = hashKey(from: url)
+        let fileURL = cacheDirectory.appendingPathComponent(key)
         
         return Future<Data?, Error> { promise in
             do {
@@ -49,6 +52,12 @@ final class CacheManager {
             }
         }
         .eraseToAnyPublisher()
+    }
+    
+    private func hashKey(from url: URL) -> String {
+        let inputData = Data(url.absoluteString.utf8)
+        let hashed = SHA256.hash(data: inputData)
+        return hashed.compactMap { String(format: "%02x", $0) }.joined()
     }
 }
 

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EmojiDTO.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/EmojiDTO.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PhotoGetherDomainInterface
 
-public struct EmojiDTO: Decodable {
+public struct EmojiDTO: Codable {
     let code: String
     let character: String
     let image: String

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/LocalShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/LocalShapeDataSourceImpl.swift
@@ -8,7 +8,7 @@ public final class LocalShapeDataSourceImpl: ShapeDataSource {
         guard let url = endpoint.request().url
         else { return Empty().eraseToAnyPublisher() }
         
-        return CacheManager(path: CacheManager.emojiPath).loadPublisher(url: url)
+        return CacheManager(path: CacheManager.Path.emoji).loadPublisher(url: url)
             .compactMap { $0 }
             .decode(type: [EmojiDTO].self, decoder: JSONDecoder())
             .eraseToAnyPublisher()

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/LocalShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/LocalShapeDataSourceImpl.swift
@@ -5,9 +5,10 @@ import PhotoGetherNetwork
 
 public final class LocalShapeDataSourceImpl: ShapeDataSource {
     public func fetchEmojiData(_ endpoint: EndPoint) -> AnyPublisher<[EmojiDTO], Error> {
-        guard let url = endpoint.request().url else { return Empty().eraseToAnyPublisher() }
+        guard let url = endpoint.request().url
+        else { return Empty().eraseToAnyPublisher() }
         
-        return CacheManager().loadPublisher(key: url.absoluteString)
+        return CacheManager(path: CacheManager.emojiPath).loadPublisher(url: url)
             .compactMap { $0 }
             .decode(type: [EmojiDTO].self, decoder: JSONDecoder())
             .eraseToAnyPublisher()

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/LocalShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/LocalShapeDataSourceImpl.swift
@@ -3,8 +3,8 @@ import Foundation
 import PhotoGetherDomainInterface
 
 public final class LocalShapeDataSourceImpl: ShapeDataSource {
-    public func fetchEmojiData() -> AnyPublisher<[EmojiDTO], Error> {
         return Empty().eraseToAnyPublisher()
+    public func fetchEmojiData(_ endpoint: EndPoint) -> AnyPublisher<[EmojiDTO], Error> {
     }
     
     public init() { }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/LocalShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/LocalShapeDataSourceImpl.swift
@@ -1,10 +1,16 @@
 import Combine
 import Foundation
 import PhotoGetherDomainInterface
+import PhotoGetherNetwork
 
 public final class LocalShapeDataSourceImpl: ShapeDataSource {
-        return Empty().eraseToAnyPublisher()
     public func fetchEmojiData(_ endpoint: EndPoint) -> AnyPublisher<[EmojiDTO], Error> {
+        guard let url = endpoint.request().url else { return Empty().eraseToAnyPublisher() }
+        
+        return CacheManager().loadPublisher(key: url.absoluteString)
+            .compactMap { $0 }
+            .decode(type: [EmojiDTO].self, decoder: JSONDecoder())
+            .eraseToAnyPublisher()
     }
     
     public init() { }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
@@ -9,9 +9,8 @@ public final class RemoteShapeDataSourceImpl: ShapeDataSource {
             .map { (emojiDTOs: [EmojiDTO]) -> [EmojiDTO] in
                 if let data = try? JSONEncoder().encode(emojiDTOs),
                    let url = endpoint.request().url {
-                    CacheManager().save(key: url.absoluteString, data: data)
+                    CacheManager(path: CacheManager.emojiPath).save(url: url, data: data)
                 }
-                
                 return emojiDTOs
             }
             .eraseToAnyPublisher()

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
@@ -9,7 +9,7 @@ public final class RemoteShapeDataSourceImpl: ShapeDataSource {
             .map { (emojiDTOs: [EmojiDTO]) -> [EmojiDTO] in
                 if let data = try? JSONEncoder().encode(emojiDTOs),
                    let url = endpoint.request().url {
-                    CacheManager(path: CacheManager.emojiPath).save(url: url, data: data)
+                    CacheManager(path: CacheManager.Path.emoji).save(url: url, data: data)
                 }
                 return emojiDTOs
             }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
@@ -4,8 +4,8 @@ import PhotoGetherNetwork
 
 public final class RemoteShapeDataSourceImpl: ShapeDataSource {
     // TODO: 페이징 적용 필요
-    public func fetchEmojiData() -> AnyPublisher<[EmojiDTO], Error> {
-        return Request.requestJSON(EmojiEndPoint())
+    public func fetchEmojiData(_ endpoint: EndPoint) -> AnyPublisher<[EmojiDTO], Error> {
+        return Request.requestJSON(endpoint)
     }
     
     public init() { }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
@@ -10,16 +10,3 @@ public final class RemoteShapeDataSourceImpl: ShapeDataSource {
     
     public init() { }
 }
-
-private struct EmojiEndPoint: EndPoint {
-    var baseURL: URL { URL(string: "https://api.api-ninjas.com")! }
-    var path: String { "v1/emoji" }
-    var method: HTTPMethod { .get }
-    // 시작 인덱스, 1회 호출당 30개씩 호출
-    var parameters: [String: Any]? { ["group": "objects", "offset": 0] }
-    var headers: [String: String]? {
-        let apiKey = Bundle.main.object(forInfoDictionaryKey: "EMOJI_API_KEY") as? String ?? ""
-        return ["X-Api-Key": apiKey]
-    }
-    var body: Encodable? { nil }
-}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/RemoteShapeDataSourceImpl.swift
@@ -6,6 +6,15 @@ public final class RemoteShapeDataSourceImpl: ShapeDataSource {
     // TODO: 페이징 적용 필요
     public func fetchEmojiData(_ endpoint: EndPoint) -> AnyPublisher<[EmojiDTO], Error> {
         return Request.requestJSON(endpoint)
+            .map { (emojiDTOs: [EmojiDTO]) -> [EmojiDTO] in
+                if let data = try? JSONEncoder().encode(emojiDTOs),
+                   let url = endpoint.request().url {
+                    CacheManager().save(key: url.absoluteString, data: data)
+                }
+                
+                return emojiDTOs
+            }
+            .eraseToAnyPublisher()
     }
     
     public init() { }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeDataSource.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeDataSource.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
+import PhotoGetherNetwork
 
 public protocol ShapeDataSource {
-    func fetchEmojiData() -> AnyPublisher<[EmojiDTO], Error>
+    func fetchEmojiData(_ endPoint: EndPoint) -> AnyPublisher<[EmojiDTO], Error>
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
@@ -3,8 +3,6 @@ import Foundation
 import PhotoGetherDomainInterface
 
 final public class ShapeRepositoryImpl: ShapeRepository {
-    // TODO: local 먼저 확인 -> remote 데이터 확인하도록 수정
-    // MARK: JSON 데이터 내부의 URL을 어느 시점에 다운로드 할것인가...?
     public func fetchEmojiList() -> AnyPublisher<[EmojiEntity], Never> {
         return remoteDataSource.fetchEmojiData()
             .map { $0.map { $0.toEntity() } }
@@ -28,7 +26,7 @@ fileprivate struct EmojiEndPoint: EndPoint {
     var baseURL: URL { URL(string: "https://api.api-ninjas.com")! }
     var path: String { "v1/emoji" }
     var method: HTTPMethod { .get }
-    // 시작 인덱스, 1회 호출당 30개씩 호출
+    /// offset 기준 30개씩 호출
     var parameters: [String: Any]? { ["group": "objects", "offset": 0] }
     var headers: [String: String]? {
         let apiKey = Bundle.main.object(forInfoDictionaryKey: "EMOJI_API_KEY") as? String ?? ""

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
@@ -5,9 +5,15 @@ import PhotoGetherNetwork
 
 final public class ShapeRepositoryImpl: ShapeRepository {
     public func fetchEmojiList() -> AnyPublisher<[EmojiEntity], Never> {
-        return remoteDataSource.fetchEmojiData(EmojiEndPoint())
+        return localDataSource.fetchEmojiData(EmojiEndPoint())
+            .catch { [weak self] _ -> AnyPublisher<[EmojiDTO], Never> in
+                guard let self else { return Just([]).eraseToAnyPublisher() }
+                
+                return remoteDataSource.fetchEmojiData(EmojiEndPoint())
+                    .replaceError(with: [])
+                    .eraseToAnyPublisher()
+            }
             .map { $0.map { $0.toEntity() } }
-            .replaceError(with: [])
             .eraseToAnyPublisher()
     }
     

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
@@ -23,3 +23,16 @@ final public class ShapeRepositoryImpl: ShapeRepository {
         self.remoteDataSource = remoteDataSource
     }
 }
+
+fileprivate struct EmojiEndPoint: EndPoint {
+    var baseURL: URL { URL(string: "https://api.api-ninjas.com")! }
+    var path: String { "v1/emoji" }
+    var method: HTTPMethod { .get }
+    // 시작 인덱스, 1회 호출당 30개씩 호출
+    var parameters: [String: Any]? { ["group": "objects", "offset": 0] }
+    var headers: [String: String]? {
+        let apiKey = Bundle.main.object(forInfoDictionaryKey: "EMOJI_API_KEY") as? String ?? ""
+        return ["X-Api-Key": apiKey]
+    }
+    var body: Encodable? { nil }
+}

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import PhotoGetherDomainInterface
+import PhotoGetherNetwork
 
 final public class ShapeRepositoryImpl: ShapeRepository {
     public func fetchEmojiList() -> AnyPublisher<[EmojiEntity], Never> {

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ShapeRepositoryImpl.swift
@@ -4,7 +4,7 @@ import PhotoGetherDomainInterface
 
 final public class ShapeRepositoryImpl: ShapeRepository {
     public func fetchEmojiList() -> AnyPublisher<[EmojiEntity], Never> {
-        return remoteDataSource.fetchEmojiData()
+        return remoteDataSource.fetchEmojiData(EmojiEndPoint())
             .map { $0.map { $0.toEntity() } }
             .replaceError(with: [])
             .eraseToAnyPublisher()

--- a/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/HTTP/EndPoint.swift
+++ b/PhotoGether/DataLayer/PhotoGetherNetwork/PhotoGetherNetwork/HTTP/EndPoint.swift
@@ -18,7 +18,10 @@ extension EndPoint {
         var url = baseURL.appendingPathComponent(path)
         var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         
-        urlComponents.queryItems = parameters?.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+        urlComponents.queryItems = parameters?
+            .sorted { $0.key < $1.key }
+            .map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+        
         url = urlComponents.url!
         
         var request = URLRequest(url: url)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeatureDemo/App/SceneDelegate.swift
@@ -80,6 +80,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let sendFrameToRepositoryGuestUseCase = SendFrameToRepositoryUseCaseImpl(
             eventConnectionRepository: eventConnectionGuestRepository
         )
+        
         let sendFrameToRepositoryHostUseCase = SendFrameToRepositoryUseCaseImpl(
             eventConnectionRepository: eventConnectionHostRepository
         )
@@ -87,6 +88,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let receiveFrameHostUseCase = ReceiveFrameUseCaseImpl(
             eventConnectionRepository: eventConnectionHostRepository
         )
+        
         let receiveFrameGuestUseCase = ReceiveFrameUseCaseImpl(
             eventConnectionRepository: eventConnectionGuestRepository
         )


### PR DESCRIPTION
## 🤔 배경
- 같은 DTO를 받기 위해 매번 API 요청을 보내는것을 방지하는 DTO 캐싱이 필요했습니다.

## 📃 작업 내역
- 처음에 `localDataSource`에서 디스크 캐시를 검색합니다.
- `localDataSource`에 캐시 데이터가 없다면 `remoteDataSource`에 요청합니다.
- Repository는 DataSource에 무관하게 DTO를 가져오도록 했습니다.

## ✅ 리뷰 노트
### 캐싱 키를 결정하는 문제
- Repository에서 같은 `EndPoint`를 이용하여 DataSoruce에 요청하도록 하기 위해서 캐싱되는 Path를 Cache/emoji/`EndPoint.request().url`로 해야 됐습니다.
- 같은 request, 같은 Data가 나오기 위해 위와 같은 방식으로 캐싱 path와 key를 결정하였습니다.
- 다만 `EndPoint` 내부에 `parameters`가 Dictionary 형태여서 **request() 메서드의 결과같이 매번 달랐습니다.**

```swift
public func request() -> URLRequest {
    ...
    
    urlComponents.queryItems = parameters?
        .sorted { $0.key < $1.key }
        .map { URLQueryItem(name: $0.key, value: "\($0.value)") }

    ....
}
```

위 처럼 Dictionary 형태의 **parameters를 한번 Key 기준으로 정렬**하여 매번 **같은 request 주소**가 나오도록 수정하였습니다.

### Cache 내부에 별도의 Path를 생성
- emoji를 제외하고 다른 API 요청이 생기는 상황을 고려하였습니다.
- `extension`에 `static`으로 선언된 `string`을 이용하여 **emoji 요청은 emoji path에 저장**되도록 하였습니다.
```swift
init(path: String) {
    self.fileManager = .default
    self.cacheDirectory = fileManager
        ...
        .appendingPathComponent(path)
    
    if !fileManager.fileExists(atPath: cacheDirectory.path) {
        do {
            try fileManager.createDirectory(
                at: cacheDirectory,
                withIntermediateDirectories: true
            )
        }
        catch { os_log(...) }
    }
}
```
- 

## 🎨 스크린샷
| 실행 결과 |
| -------------- |
| ![DTO caching](https://github.com/user-attachments/assets/4374755f-7b14-4db9-87b2-0bbf6e56d2e9) |


## 🚀 테스트 방법
EditPhotoRoomFeatureDemo를 실행 후 첫 request가 remote에서 오고 두번째 실행시에는 disk에서 불러오면 성공입니다.