### PR TITLE
[FEAT/#118] SharePhoto의 사진 앱 저장 기능 구현 및 리팩터링

### DIFF
--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature.xcodeproj/project.pbxproj
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature.xcodeproj/project.pbxproj
@@ -11,8 +11,13 @@
 		055503C52CDB5608004D34EB /* SharePhotoFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 055503882CDB54AF004D34EB /* SharePhotoFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		60B03BF32CE4CEDC00A7C748 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60B03BF22CE4CEDC00A7C748 /* DesignSystem.framework */; };
 		60B03BF42CE4CEDC00A7C748 /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 60B03BF22CE4CEDC00A7C748 /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		7B59510F2CDB598E00B89C85 /* FeatureTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B59510E2CDB598E00B89C85 /* FeatureTesting.framework */; };
-		7B5951102CDB598E00B89C85 /* FeatureTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B59510E2CDB598E00B89C85 /* FeatureTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		60CA8C6A2CF7556F00F1A8E5 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60B03BF22CE4CEDC00A7C748 /* DesignSystem.framework */; };
+		60CA8C6B2CF7556F00F1A8E5 /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 60B03BF22CE4CEDC00A7C748 /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		60CA8C6F2CF755B400F1A8E5 /* PhotoGetherDomainInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5951D12CDB664300B89C85 /* PhotoGetherDomainInterface.framework */; };
+		60CA8C702CF755B400F1A8E5 /* PhotoGetherDomainInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5951D12CDB664300B89C85 /* PhotoGetherDomainInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		60CA8C712CF755F300F1A8E5 /* BaseFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5951512CDB600100B89C85 /* BaseFeature.framework */; };
+		60CA8C722CF755F300F1A8E5 /* BaseFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5951512CDB600100B89C85 /* BaseFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		60CA8C782CF7573500F1A8E5 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 60CA8C772CF7573500F1A8E5 /* WebRTC */; };
 		7B5951522CDB600100B89C85 /* BaseFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5951512CDB600100B89C85 /* BaseFeature.framework */; };
 		7B5951532CDB600100B89C85 /* BaseFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5951512CDB600100B89C85 /* BaseFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B5951D22CDB664300B89C85 /* PhotoGetherDomainInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5951D12CDB664300B89C85 /* PhotoGetherDomainInterface.framework */; };
@@ -36,8 +41,10 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				7B5951102CDB598E00B89C85 /* FeatureTesting.framework in Embed Frameworks */,
+				60CA8C6B2CF7556F00F1A8E5 /* DesignSystem.framework in Embed Frameworks */,
 				055503C52CDB5608004D34EB /* SharePhotoFeature.framework in Embed Frameworks */,
+				60CA8C702CF755B400F1A8E5 /* PhotoGetherDomainInterface.framework in Embed Frameworks */,
+				60CA8C722CF755F300F1A8E5 /* BaseFeature.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -61,6 +68,8 @@
 		055503882CDB54AF004D34EB /* SharePhotoFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SharePhotoFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		055503982CDB54F6004D34EB /* SharePhotoFeatureDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SharePhotoFeatureDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60B03BF22CE4CEDC00A7C748 /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		60CA8C6C2CF7559C00F1A8E5 /* EditPhotoRoomFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EditPhotoRoomFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		60CA8C732CF7563200F1A8E5 /* PhotoGetherDomainTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PhotoGetherDomainTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B59510E2CDB598E00B89C85 /* FeatureTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FeatureTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B5951512CDB600100B89C85 /* BaseFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BaseFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B59517A2CDB62A600B89C85 /* PresentationUtility.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PresentationUtility.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -108,8 +117,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7B59510F2CDB598E00B89C85 /* FeatureTesting.framework in Frameworks */,
+				60CA8C782CF7573500F1A8E5 /* WebRTC in Frameworks */,
+				60CA8C6A2CF7556F00F1A8E5 /* DesignSystem.framework in Frameworks */,
 				055503C42CDB5608004D34EB /* SharePhotoFeature.framework in Frameworks */,
+				60CA8C6F2CF755B400F1A8E5 /* PhotoGetherDomainInterface.framework in Frameworks */,
+				60CA8C712CF755F300F1A8E5 /* BaseFeature.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -138,6 +150,8 @@
 		055503C32CDB5608004D34EB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				60CA8C732CF7563200F1A8E5 /* PhotoGetherDomainTesting.framework */,
+				60CA8C6C2CF7559C00F1A8E5 /* EditPhotoRoomFeature.framework */,
 				60B03BF22CE4CEDC00A7C748 /* DesignSystem.framework */,
 				7B5951D12CDB664300B89C85 /* PhotoGetherDomainInterface.framework */,
 				7B59517A2CDB62A600B89C85 /* PresentationUtility.framework */,
@@ -203,6 +217,7 @@
 			);
 			name = SharePhotoFeatureDemo;
 			packageProductDependencies = (
+				60CA8C772CF7573500F1A8E5 /* WebRTC */,
 			);
 			productName = SharePhotoFeatureDemo;
 			productReference = 055503982CDB54F6004D34EB /* SharePhotoFeatureDemo.app */;
@@ -235,6 +250,9 @@
 			);
 			mainGroup = 0555037E2CDB54AF004D34EB;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				60CA8C762CF7573500F1A8E5 /* XCRemoteSwiftPackageReference "WebRTC" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 055503892CDB54AF004D34EB /* Products */;
 			projectDirPath = "";
@@ -585,6 +603,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		60CA8C762CF7573500F1A8E5 /* XCRemoteSwiftPackageReference "WebRTC" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/stasel/WebRTC.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 130.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		60CA8C772CF7573500F1A8E5 /* WebRTC */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 60CA8C762CF7573500F1A8E5 /* XCRemoteSwiftPackageReference "WebRTC" */;
+			productName = WebRTC;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 0555037F2CDB54AF004D34EB /* Project object */;
 }

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewController.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewController.swift
@@ -101,6 +101,10 @@ public class SharePhotoViewController: BaseViewController, ViewControllerConfigu
                 switch event {
                 case .showShareSheet:
                     self?.showShareSheet()
+                case .showSaveToast:
+                    self?.showToast(message: "사진이 저장되었습니다.")
+                case .showFailToast:
+                    self?.showToast(message: "저장 실패")
                 case .showAuthorizationAlert:
                     self?.showAutorizationAlert()
                 }

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewController.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewController.swift
@@ -101,6 +101,8 @@ public class SharePhotoViewController: BaseViewController, ViewControllerConfigu
                 switch event {
                 case .showShareSheet:
                     self?.showShareSheet()
+                case .showAuthorizationAlert:
+                    self?.showAutorizationAlert()
                 }
             }
             .store(in: &cancellables)
@@ -118,6 +120,18 @@ public class SharePhotoViewController: BaseViewController, ViewControllerConfigu
         }
     }
     
+    private func showAutorizationAlert() {
+        let alert = UIAlertController(
+            title: "사진 앱 접근 권한 필요",
+            message: "사진을 저장하려면 설정에서 사진 앱에 대한 접근 권한을 허용해주세요.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: "설정", style: .default, handler: { _ in
+            if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(settingsURL)
+            }
+        }))
         present(alert, animated: true)
     }
 }

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewController.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewController.swift
@@ -118,5 +118,6 @@ public class SharePhotoViewController: BaseViewController, ViewControllerConfigu
         }
     }
     
+        present(alert, animated: true)
     }
 }

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewModel.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewModel.swift
@@ -3,9 +3,34 @@ import Foundation
 import PhotoGetherDomainInterface
 
 public final class SharePhotoViewModel {
+    enum Input {
+        case shareButtonDidTap
+        case saveButtonDidTap
+    }
+    
+    enum Output {
+        case showShareSheet
+    }
+    
     public private(set) var photoData: Data
+    
+    private let output = PassthroughSubject<Output, Never>()
+    
+    private var cancellables = Set<AnyCancellable>()
     
     public init(component: SharePhotoComponent) {
         self.photoData = component.photoData
+    }
+    
+    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
+        input.sink { [weak self] event in
+            switch event {
+            case .shareButtonDidTap:
+            case .saveButtonDidTap:
+            }
+        }
+        .store(in: &cancellables)
+        
+        return output.eraseToAnyPublisher()
     }
 }

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewModel.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewModel.swift
@@ -10,6 +10,7 @@ public final class SharePhotoViewModel {
     
     enum Output {
         case showShareSheet
+        case showAuthorizationAlert
     }
     
     public private(set) var photoData: Data
@@ -26,11 +27,19 @@ public final class SharePhotoViewModel {
         input.sink { [weak self] event in
             switch event {
             case .shareButtonDidTap:
+                self?.output.send(.showShareSheet)
             case .saveButtonDidTap:
+                Task { await self?.handleSaveButtonDidTap() }
             }
         }
         .store(in: &cancellables)
         
         return output.eraseToAnyPublisher()
+    }
+    private func handleSaveButtonDidTap() async {
+        guard await isAuthorized() else {
+            output.send(.showAuthorizationAlert)
+            return
+        }
     }
 }

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewModel.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewModel.swift
@@ -10,6 +10,8 @@ public final class SharePhotoViewModel {
     
     enum Output {
         case showShareSheet
+        case showSaveToast
+        case showFailToast
         case showAuthorizationAlert
     }
     
@@ -36,6 +38,7 @@ public final class SharePhotoViewModel {
         
         return output.eraseToAnyPublisher()
     }
+    
     private func handleSaveButtonDidTap() async {
         guard await isAuthorized() else {
             output.send(.showAuthorizationAlert)

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewModel.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/SharePhotoViewModel.swift
@@ -41,5 +41,16 @@ public final class SharePhotoViewModel {
             output.send(.showAuthorizationAlert)
             return
         }
+        
+        let isSuccess = await savePhoto()
+        output.send(isSuccess ? .showSaveToast : .showFailToast)
+    }
+    
+    private func savePhoto() async -> Bool {
+        return await PhotoLibraryHelper.savePhoto(with: photoData)
+    }
+    
+    private func isAuthorized() async -> Bool {
+        return await PhotoLibraryPermissionManager.checkPhotoPermission()
     }
 }

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/Utility/PhotoLibraryHelper.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/Utility/PhotoLibraryHelper.swift
@@ -1,0 +1,22 @@
+import UIKit
+import Photos
+
+struct PhotoLibraryHelper {
+    static func savePhoto(with data: Data) async -> Bool {
+        
+        guard let photoImage = UIImage(data: data) else { return false }
+        
+        return await withCheckedContinuation { continuation in
+            PHPhotoLibrary.shared().performChanges({
+                PHAssetChangeRequest.creationRequestForAsset(from: photoImage)
+            }) { success, error in
+                if let error = error {
+                    print("Error saving photo: \(error.localizedDescription)")
+                } else if success {
+                    print("Photo saved successfully!")
+                }
+                continuation.resume(returning: success)
+            }
+        }
+    }
+}

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/Utility/PhotoLibraryPermissionManager.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeature/Source/Utility/PhotoLibraryPermissionManager.swift
@@ -1,0 +1,27 @@
+import Photos
+
+struct PhotoLibraryPermissionManager {
+    static func checkPhotoPermission() async -> Bool {
+        let status = PHPhotoLibrary.authorizationStatus()
+        print(status)
+        switch status {
+        case .notDetermined:
+            return await requestAuthorization()
+        case .authorized, .limited:
+            return true
+        case .denied, .restricted:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    private static func requestAuthorization() async -> Bool {
+        return await withCheckedContinuation { continuation in
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
+                let isAuthorized = (newStatus == .authorized || newStatus == .limited)
+                continuation.resume(returning: isAuthorized)
+            }
+        }
+    }
+}

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeatureDemo/App/SceneDelegate.swift
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeatureDemo/App/SceneDelegate.swift
@@ -1,5 +1,4 @@
 import DesignSystem
-import EditPhotoRoomFeature
 import PhotoGetherDomainInterface
 import SharePhotoFeature
 import UIKit
@@ -15,18 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
-        // MARK: PhotoRoom -> EditPhotoRoom
-        let images: [UIImage] = [
-            PTGImage.temp1.image,
-            PTGImage.temp2.image,
-            PTGImage.temp3.image,
-            PTGImage.temp4.image
-        ]
-        
-        // MARK: EditPhotoRoom ~ ing
-        let imageGenerator: FrameImageGenerator = FrameImageGeneratorImpl(images: images)
-        imageGenerator.changeFrame(to: .defaultWhite)
-        let image = imageGenerator.generate()
+        let image = PTGImage.sampleImage.image
         
         // MARK: EditPhotoRoom -> SharePhotoRoom
         let imageData = image.pngData() ?? Data()

--- a/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeatureDemo/Resource/Info.plist
+++ b/PhotoGether/PresentationLayer/SharePhotoFeature/SharePhotoFeatureDemo/Resource/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>사진 앱에 대한 접근 권한이 필요합니다.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>사진을 앨범에 저장하려면 접근 권한이 필요합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## 🤔 배경
사진을 저장하거나 공유하는 기능을 구현하면서, 사진 라이브러리 접근 권한 요청 및 사진 저장 관련 로직이 필요했습니다. 
이에 따라, 권한 요청과 사진 저장 기능을 관리하는 구조를 설계해야 했습니다.
다른 피쳐와 마찬가지로 권한 및 사진 저장 담당을 in/out 패턴으로 구현 및 리팩터링 했습니다.

## 📃 작업 내역
### 사진 접근 권한 관련
- Info.plist에 사진 접근 권한 키를 추가했습니다.
<img width="765" alt="image" src="https://github.com/user-attachments/assets/91954ed4-a8e8-4aa1-ab5e-f808ebe0cea0">

### 유틸리티 추가
- 사진 권한, 앨범에 사진 저장을 위해 `PhotoLibraryPermissionManager`와 `PhotoLibraryHelper`를 구현했습니다.

### UI 구현
- 권한 접근 관련 Alert UI를 구현했습니다.
- 저장 성공 시 유저 인터랙션을 위한 토스트 UI를 활용했습니다.

## ✅ 리뷰 노트
### 권한 관련
```swift
    static func checkPhotoPermission() async -> Bool {
        let status = PHPhotoLibrary.authorizationStatus()
        print(status)
        switch status {
        case .notDetermined:
            return await requestAuthorization()
        case .authorized, .limited:
            return true
        case .denied, .restricted:
            return false
        @unknown default:
            return false
        }
    }
```
- `.notDetermined`: 사진 접근 권한을 부여하지 않은 상태입니다. `requestAuthorization()`로 권한 요청을 진행합니다.
- `.authorized, .limited`: 사진 접근 권한이 허용되거나 일부 제한된 상태로 권한이 충분하므로 사진 저장을 할 수 있습니다.
- `.denied, .restricted`: 사용자가 명시적으로 접근을 거부하거나 / 시스템 정책에 따라 접근이 제한된 상태이므로 권한 설정을 유도하는 알러트를 두었습니다.

### 비동기 로직 구현
- 권한 요청 및 사진 저장에서 비동기 로직이 사용되어야 했습니다.
- `async/await`를 활용하여 비동기 처리를 단순화했습니다.
- `escaping` 콜백 기반의 코드보다 가독성이 좋아 활용해보았습니다.

```swift
func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
    input.sink { [weak self] event in
        switch event {
        case .shareButtonDidTap:
            self?.output.send(.showShareSheet)
        case .saveButtonDidTap:
            Task { await self?.handleSaveButtonDidTap() }
        }
    }
    .store(in: &cancellables)
    
    return output.eraseToAnyPublisher()
}

private func handleSaveButtonDidTap() async {
    guard await isAuthorized() else {
        output.send(.showAuthorizationAlert)
        return
    }
    
    let isSuccess = await savePhoto()
    output.send(isSuccess ? .showSaveToast : .showFailToast)
}

private func savePhoto() async -> Bool {
    return await PhotoLibraryHelper.savePhoto(with: photoData)
}

private func isAuthorized() async -> Bool {
    return await PhotoLibraryPermissionManager.checkPhotoPermission()
}
```

## 🎨 스크린샷
| `.notDetermined` | `.authorized`, `.limited` | `.denied`, `.restricted` |
| -------------- | -------------- | -------------- |
| ![권한](https://github.com/user-attachments/assets/6bb01b3b-759f-45ac-a1cd-70739f874f6d) | ![토스트](https://github.com/user-attachments/assets/494540b9-14fe-4424-a716-4546da72680b) | ![일부 접근](https://github.com/user-attachments/assets/25fae23a-879a-4b45-9e5f-dac75f578e16) |



## 🚀 테스트 방법
`SharePhotoFeatureDemo`를 실행하고 저장, 공유 버튼 기능을 테스트해볼 수 있습니다.
