### PR TITLE
[FIX/#122] 이미지 캐시 메서드로 변경 및 바텀 시트 present detent 에러 수정

### DIFF
--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/StickerBottomSheetViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/StickerBottomSheetViewController.swift
@@ -41,6 +41,12 @@ public final class StickerBottomSheetViewController: UIViewController, ViewContr
         self.bindOutput()
     }
     
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        self.sheetPresentationController?.detents = [.medium(), .large()]
+    }
+    
     private func setupCollectionView() {
         self.collectionView.delegate = self
         self.collectionView.dataSource = self
@@ -62,7 +68,6 @@ public final class StickerBottomSheetViewController: UIViewController, ViewContr
     }
     
     public func configureUI() {
-        self.sheetPresentationController?.detents = [.medium(), .large()]
         self.view.backgroundColor = PTGColor.gray10.color
     }
     

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/StickerCollectionViewCell.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/StickerCollectionViewCell.swift
@@ -32,12 +32,7 @@ final class StickerCollectionViewCell: UICollectionViewCell {
     private func configureUI() { }
     
     func setupImage(by emoji: EmojiEntity) {
-        Task {
-            guard let url = URL(string: emoji.image),
-                  let (data, _) = try? await URLSession.shared.data(from: url)
-            else { return }
-            
-            self.imageView.image = UIImage(data: data)
-        }
+        guard let url = URL(string: emoji.image) else { return }
+        Task { await imageView.setAsyncImage(url) }
     }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
@@ -76,13 +76,7 @@ final class StickerView: UIImageView {
     
     private func setImage(to urlString: String) {
         guard let url = URL(string: urlString) else { return }
-        
-        Task { [weak self] in
-            guard let (data, _) = try? await URLSession.shared.data(from: url)
-            else { return }
-            
-            self?.image = UIImage(data: data)
-        }
+        Task { await self.setAsyncImage(url) }
     }
     
     @objc private func handleTap() {


### PR DESCRIPTION
## 🤔 배경
- ImageView의 이미지를 캐싱하여 느린 다운로드 문제를 해결해야 했다.
- BottomSheet가 present될 때 half modal이 처음에만 적용되던 문제를 해결해야 했다.

## 📃 작업 내역

- URLSession을 이용하여 image download 하던 부분들을 수정하였습니다.
- BottomSheet의 detent 설정 시기를 수정하였습니다.

## ✅ 리뷰 노트

**🏝️ 캐시 조아 🏝️**

**👻 하프 모달 조아 👻**

## 🚀 테스트 방법
- 편집 화면에서 스티커 버튼을 눌러 바텀시트도 반만 뜨고, 확대가 되는지 확인해보세요!
- 이미지를 캐시로딩 하기에 빨라진 로딩 속도를 확인해보세요!