### PR TITLE
[HOTFIX/#137] 다인 연결이 안되던 문제를 수정합니다.

### DIFF
--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionClientImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionClientImpl.swift
@@ -8,8 +8,16 @@ public final class ConnectionClientImpl: ConnectionClient {
     
     private let webRTCService: WebRTCService
     
-    public var receivedDataPublisher = PassthroughSubject<Data, Never>()
+    private let receivedDataSubject = PassthroughSubject<Data, Never>()
+    private let didGenerateLocalCandidateSubejct = PassthroughSubject<(receiverID: String, RTCIceCandidate), Never>()
     
+    public var receivedDataPublisher: AnyPublisher<Data, Never> {
+        receivedDataSubject.eraseToAnyPublisher()
+    }
+    public var didGenerateLocalCandidatePublisher: AnyPublisher<(receiverID: String, RTCIceCandidate), Never> {
+        didGenerateLocalCandidateSubejct.eraseToAnyPublisher()
+    }
+        
     public var remoteVideoView: UIView = CapturableVideoView()
     public var remoteUserInfo: UserInfo?
         
@@ -20,7 +28,6 @@ public final class ConnectionClientImpl: ConnectionClient {
         self.webRTCService = webRTCService
         self.remoteUserInfo = remoteUserInfo
         
-        bindSignalingService()
         bindWebRTCService()
                 
         // VideoTrack과 나와 상대방의 화면을 볼 수 있는 뷰를 바인딩합니다.
@@ -31,28 +38,31 @@ public final class ConnectionClientImpl: ConnectionClient {
         self.remoteUserInfo = remoteUserInfo
     }
     
-    // MARK: 해당 클라이언트에게 보낼 Offer SDP를 생성합니다.
+    /// 해당 클라이언트에게 보낼 Offer SDP를 생성합니다.
     public func createOffer() async throws -> RTCSessionDescription {
         guard remoteUserInfo != nil else { throw NSError() }
         return try await self.webRTCService.offer()
     }
     
-//    public func sendOffer(myID: String) {
-//        guard let remoteUserInfo else { return }
-//        
-//        self.webRTCService.offer { sdp in
-//            self.signalingService.send(
-//                type: .offerSDP,
-//                sdp: sdp,
-//                roomID: remoteUserInfo.roomID,
-//                offerID: myID,
-//                answerID: nil
-//            )
-//        }
-//    }
+    /// 해당 클라이언트에게 보낼 Answer SDP를 생성합니다.
+    public func createAnswer() async throws -> RTCSessionDescription {
+        guard remoteUserInfo != nil else { throw NSError() }
+        return try await self.webRTCService.answer()
+    }
     
+    /// 해당 클라이언트에게 WebRTC DataChannel을 통해 데이터를 전송합니다.
     public func sendData(data: Data) {
         self.webRTCService.sendData(data)
+    }
+    
+    public func set(remoteSdp: RTCSessionDescription) async throws {
+        try await self.webRTCService.set(remoteSdp: remoteSdp)
+    }
+    public func set(localSdp: RTCSessionDescription) async throws {
+        try await self.webRTCService.set(localSdp: localSdp)
+    }
+    public func set(remoteCandidate: RTCIceCandidate) async throws {
+        try await self.webRTCService.set(remoteCandidate: remoteCandidate)
     }
     
     public func captureVideo() -> UIImage {
@@ -67,7 +77,6 @@ public final class ConnectionClientImpl: ConnectionClient {
         return capturedImage
     }
     
-    
     /// remoteVideoTrack과 상대방의 화면을 볼 수 있는 뷰를 바인딩합니다.
     private func bindRemoteVideo() {
         guard let remoteVideoView = remoteVideoView as? RTCMTLVideoView else { return }
@@ -78,107 +87,16 @@ public final class ConnectionClientImpl: ConnectionClient {
         guard let localVideoView = localVideoView as? RTCMTLVideoView else { return }
         self.webRTCService.startCaptureLocalVideo(renderer: localVideoView)
     }
-    
-    private func bindSignalingService() {
-        // MARK: 이미 방에 있던 놈들이 받는 이벤트
-        self.signalingService.didReceiveOfferSdpPublisher
-            .filter { [weak self] _ in self?.remoteUserInfo != nil }
-            .sink { [weak self] sdpMessage in
-                guard let self else { return }
-                let remoteSDP = sdpMessage.rtcSessionDescription
-                
-                PTGDataLogger.log("didReceiveRemoteSdpPublisher sink!! \(remoteSDP)")
-                
-                // MARK: remoteDescription이 있으면 이미 연결된 클라이언트
-                guard self.webRTCService.peerConnection.remoteDescription == nil else {
-                    PTGDataLogger.log("remoteSDP가 이미 있어요!")
-                    return
-                }
-                PTGDataLogger.log("remoteSDP가 없어요! remoteSDP 저장하기 직전")
-                guard let userInfo = self.remoteUserInfo else {
-                    PTGDataLogger.log("answer를 받을 remote User가 없어요!! 비상!!!")
-                    return
-                }
-                
-                guard userInfo.id == sdpMessage.offerID else {
-                    PTGDataLogger.log("Offer를 보낸 유저가 일치하지 않습니다.")
-                    return
-                }
-                
-                guard self.webRTCService.peerConnection.localDescription == nil else {
-                    PTGDataLogger.log("localSDP가 이미 있어요!")
-                    return
-                }
-                
-            self.webRTCService.set(remoteSdp: remoteSDP) { error in
-                PTGDataLogger.log("remoteSDP가 저장되었어요!")
-
-                if let error { PTGDataLogger.log(error.localizedDescription) }
-                
-                self.webRTCService.answer { sdp in
-                    self.signalingService.send(
-                        type: .answerSDP,
-                        sdp: sdp,
-                        roomID: userInfo.roomID,
-                        offerID: userInfo.id,
-                        answerID: sdpMessage.answerID
-                    )
-                }
-            }
-        }.store(in: &cancellables)
         
-        self.signalingService.didReceiveAnswerSdpPublisher
-            .filter { [weak self] _ in self?.remoteUserInfo != nil }
-            .sink { [weak self] sdpMessage in
-                guard let self else { return }
-                let remoteSDP = sdpMessage.rtcSessionDescription
-                
-                guard let userInfo = remoteUserInfo else {
-                    PTGDataLogger.log("UserInfo가 없어요")
-                    return
-                }
-                
-                guard userInfo.id == sdpMessage.answerID else {
-                    return
-                }
-                
-                guard self.webRTCService.peerConnection.localDescription != nil else {
-                    PTGDataLogger.log("localDescription이 없어요")
-                    return
-                }
-                
-                guard self.webRTCService.peerConnection.remoteDescription == nil else {
-                    PTGDataLogger.log("remoteDescription이 있어요")
-                    return
-                }
-                
-                self.webRTCService.set(remoteSdp: remoteSDP) { error in
-                    if let error = error {
-                        PTGDataLogger.log("Error setting remote SDP: \(error.localizedDescription)")
-                    }
-                }
-            }.store(in: &cancellables)
-        
-        self.signalingService.didReceiveCandidatePublisher.sink { [weak self] candidate in
-            guard let self else { return }
-            self.webRTCService.set(remoteCandidate: candidate) { _ in }
-        }.store(in: &cancellables)
-    }
-    
     private func bindWebRTCService() {
         self.webRTCService.didReceiveDataPublisher.sink { [weak self] data in
             guard let self else { return }
-            receivedDataPublisher.send(data)
+            receivedDataSubject.send(data)
         }.store(in: &cancellables)
         
         self.webRTCService.didGenerateLocalCandidatePublisher.sink { [weak self] candidate in
             guard let self, let remoteUserInfo else { return }
-            self.signalingService.send(
-                type: .iceCandidate,
-                candidate: candidate,
-                roomID: remoteUserInfo.roomID,
-                userID: remoteUserInfo.id
-            )
+            self.didGenerateLocalCandidateSubejct.send((receiverID: remoteUserInfo.id, candidate))
         }.store(in: &cancellables)
     }
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
@@ -135,7 +135,7 @@ extension ConnectionRepositoryImpl {
                     do {
                         try await answerReceiver.set(remoteSdp: remoteSDP)
                     } catch {
-                        PTGDataLogger.log("Answer SDP 수신 중 에러: \(error.localizedDescription)")
+                        PTGDataLogger.log("Answer SDP 저장 중 에러: \(error.localizedDescription)")
                     }
                 }
             }.store(in: &cancellables)
@@ -151,7 +151,7 @@ extension ConnectionRepositoryImpl {
                 do {
                     try await candidateReceiver.set(remoteCandidate: candidate.rtcIceCandidate)
                 } catch {
-                    PTGDataLogger.log("Candidate 수신 중 에러: \(error.localizedDescription)")
+                    PTGDataLogger.log("Candidate 저장 중 에러: \(error.localizedDescription) \(candidate.sdp)")
                 }
             }
             
@@ -198,11 +198,11 @@ extension ConnectionRepositoryImpl {
         clients.forEach {
             $0.didGenerateLocalCandidatePublisher.sink { [weak self] receiverID, candidate in
                 guard let self else { return }
+                PTGDataLogger.log("didGenerateLocalCandidatePublisher: \(receiverID)")
                 guard let localUserInfo = self.localUserInfo else {
                     PTGDataLogger.log("localUserInfo가 없어요!! 비상!!!")
                     return
                 }
-                
                 self.signalingService.send(
                     type: .iceCandidate,
                     candidate: candidate,

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
@@ -57,7 +57,7 @@ public final class ConnectionRepositoryImpl: ConnectionRepository {
         guard let myID = localUserInfo?.id else { throw NSError() }
         guard let roomID = localUserInfo?.roomID else { throw NSError() }
         
-        for client in self.clients {
+        for client in self.clients where client.remoteUserInfo != nil {
             guard let sdp = try? await client.createOffer() else {
                 PTGDataLogger.log("offer 생성 중 에러가 발생했습니다.")
                 throw NSError()

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
@@ -44,7 +44,7 @@ public final class ConnectionRepositoryImpl: ConnectionRepository {
     public func joinRoom(to roomID: String, hostID: String) -> AnyPublisher<Bool, Error> {
         return roomService.joinRoom(to: roomID).map { [weak self] entity -> Bool in
             guard let self else { return false }
-            guard entity.userList.count <= clients.count else { return false }
+            guard entity.userList.count <= clients.count + 1 else { return false }
             let setLocalUserInfoResult = setLocalUserInfo(entity: entity)
             let setRemoteUserInfoResult = setRemoteUserInfo(entity: entity, hostID: hostID)
             
@@ -62,12 +62,15 @@ public final class ConnectionRepositoryImpl: ConnectionRepository {
                 PTGDataLogger.log("offer 생성 중 에러가 발생했습니다.")
                 throw NSError()
             }
+            
+            guard let remoteUserInfo = client.remoteUserInfo else { return }
+            
             self.signalingService.send(
                 type: .offerSDP,
                 sdp: sdp,
                 roomID: roomID,
                 offerID: myID,
-                answerID: nil
+                answerID: remoteUserInfo.id
             )
         }
     }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
@@ -140,8 +140,8 @@ extension ConnectionRepositoryImpl {
         self.signalingService.didReceiveCandidatePublisher.sink { [weak self] candidate in
             guard let self else { return }
 
-            guard let candidateReceiver = self.clients.first(where: { $0.remoteUserInfo?.id == candidate.userID }) else {
-                PTGDataLogger.log("candidateReceiver가 없어요! \(candidate.userID)")
+            guard let candidateReceiver = self.clients.first(where: { $0.remoteUserInfo?.id == candidate.senderID }) else {
+                PTGDataLogger.log("candidateReceiver가 없어요! \(candidate.senderID)")
                 return
             }
             Task {
@@ -204,7 +204,8 @@ extension ConnectionRepositoryImpl {
                     type: .iceCandidate,
                     candidate: candidate,
                     roomID: localUserInfo.roomID,
-                    userID: receiverID
+                    receiverID: receiverID,
+                    senderID: localUserInfo.id
                 )
             }.store(in: &cancellables)
         }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
@@ -26,6 +26,7 @@ public final class ConnectionRepositoryImpl: ConnectionRepository {
         self.roomService = roomService
         self.clients = clients
         
+        bindSignalingService()
         connectSignalingService()
         bindLocalVideo()
         bindNotifyNewUserPublihser()

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
@@ -15,10 +15,17 @@ public final class ConnectionRepositoryImpl: ConnectionRepository {
     public var capturedLocalVideo: UIImage? { _localVideoView.capturedImage }
     
     private let roomService: RoomService
+    private let signalingService: SignalingService
     
-    public init(clients: [ConnectionClient], roomService: RoomService) {
+    public init(
+        clients: [ConnectionClient],
+        roomService: RoomService,
+        signlingService: SignalingService
+    ) {
         self.clients = clients
         self.roomService = roomService
+        self.signalingService = signlingService
+        connectSignalingService()
         bindLocalVideo()
         bindNotifyNewUserPublihser()
     }
@@ -43,14 +50,121 @@ public final class ConnectionRepositoryImpl: ConnectionRepository {
         .eraseToAnyPublisher()
     }
     
-    public func sendOffer() -> Bool {
+    public func sendOffer() async -> Bool {
         guard let myID = localUserInfo?.id else { return false }
-        clients.forEach { $0.sendOffer(myID: myID) }
+        guard let roomID = localUserInfo?.roomID else { return false }
+        
+        for client in self.clients {
+            do {
+                let sdp = try await client.createOffer()
+                self.signalingService.send(
+                    type: .offerSDP,
+                    sdp: sdp,
+                    roomID: roomID,
+                    offerID: myID,
+                    answerID: nil
+                )
+            } catch {
+                PTGDataLogger.log("offer 생성 중 에러가 발생했습니다. \(error.localizedDescription)")
+                return false
+            }
+        }
+        
         return true
     }
 }
 
 extension ConnectionRepositoryImpl {
+    private func connectSignalingService() {
+        self.signalingService.connect()
+    }
+    
+    private func bindSignalingService() {
+        // MARK: 이미 방에 있던 놈들이 받는 이벤트
+        self.signalingService.didReceiveOfferSdpPublisher
+            .filter { [weak self] _ in self?.remoteUserInfo != nil }
+            .sink { [weak self] sdpMessage in
+                guard let self else { return }
+                let remoteSDP = sdpMessage.rtcSessionDescription
+                
+                PTGDataLogger.log("didReceiveRemoteSdpPublisher sink!! \(remoteSDP)")
+                
+                // MARK: remoteDescription이 있으면 이미 연결된 클라이언트
+                guard self.webRTCService.peerConnection.remoteDescription == nil else {
+                    PTGDataLogger.log("remoteSDP가 이미 있어요!")
+                    return
+                }
+                PTGDataLogger.log("remoteSDP가 없어요! remoteSDP 저장하기 직전")
+                guard let userInfo = self.remoteUserInfo else {
+                    PTGDataLogger.log("answer를 받을 remote User가 없어요!! 비상!!!")
+                    return
+                }
+                
+                guard userInfo.id == sdpMessage.offerID else {
+                    PTGDataLogger.log("Offer를 보낸 유저가 일치하지 않습니다.")
+                    return
+                }
+                
+                guard self.webRTCService.peerConnection.localDescription == nil else {
+                    PTGDataLogger.log("localSDP가 이미 있어요!")
+                    return
+                }
+                
+            self.webRTCService.set(remoteSdp: remoteSDP) { error in
+                PTGDataLogger.log("remoteSDP가 저장되었어요!")
+
+                if let error { PTGDataLogger.log(error.localizedDescription) }
+                
+                self.webRTCService.answer { sdp in
+                    self.signalingService.send(
+                        type: .answerSDP,
+                        sdp: sdp,
+                        roomID: userInfo.roomID,
+                        offerID: userInfo.id,
+                        answerID: sdpMessage.answerID
+                    )
+                }
+            }
+        }.store(in: &cancellables)
+        
+        self.signalingService.didReceiveAnswerSdpPublisher
+            .filter { [weak self] _ in self?.remoteUserInfo != nil }
+            .sink { [weak self] sdpMessage in
+                guard let self else { return }
+                let remoteSDP = sdpMessage.rtcSessionDescription
+                
+                guard let userInfo = remoteUserInfo else {
+                    PTGDataLogger.log("UserInfo가 없어요")
+                    return
+                }
+                
+                guard userInfo.id == sdpMessage.answerID else {
+                    return
+                }
+                
+                guard self.webRTCService.peerConnection.localDescription != nil else {
+                    PTGDataLogger.log("localDescription이 없어요")
+                    return
+                }
+                
+                guard self.webRTCService.peerConnection.remoteDescription == nil else {
+                    PTGDataLogger.log("remoteDescription이 있어요")
+                    return
+                }
+                
+                self.webRTCService.set(remoteSdp: remoteSDP) { error in
+                    if let error = error {
+                        PTGDataLogger.log("Error setting remote SDP: \(error.localizedDescription)")
+                    }
+                }
+            }.store(in: &cancellables)
+        
+        self.signalingService.didReceiveCandidatePublisher.sink { [weak self] candidate in
+            guard let self else { return }
+            self.webRTCService.set(remoteCandidate: candidate) { _ in }
+        }.store(in: &cancellables)
+    }
+    
     private func bindLocalVideo() {
         self.clients.forEach { $0.bindLocalVideo(_localVideoView) }
     }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/IceCandidateMessage.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/IceCandidateMessage.swift
@@ -6,15 +6,23 @@ public struct IceCandidateMessage: Codable {
     public let sdpMLineIndex: Int32
     public let sdpMid: String?
     /// 받는 사람의 ID
-    public let userID: String
+    public let receiverID: String
+    /// 보내는 사람의 ID
+    public let senderID: String
     /// 참가하려는 방의 ID
     public let roomID: String
     
-    public init(from iceCandidate: RTCIceCandidate, userID: String, roomID: String) {
+    public init(
+        from iceCandidate: RTCIceCandidate,
+        receiverID: String,
+        senderID: String,
+        roomID: String
+    ) {
         self.sdpMLineIndex = iceCandidate.sdpMLineIndex
         self.sdpMid = iceCandidate.sdpMid
         self.sdp = iceCandidate.sdp
-        self.userID = userID
+        self.receiverID = receiverID
+        self.senderID = senderID
         self.roomID = roomID
     }
     

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/IceCandidateMessage.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/IceCandidateMessage.swift
@@ -5,8 +5,10 @@ public struct IceCandidateMessage: Codable {
     public let sdp: String
     public let sdpMLineIndex: Int32
     public let sdpMid: String?
-    public let userID: String // MARK: 받는 사람의 ID
-    public let roomID: String // MARK: 참가하려는 방의 ID
+    /// 받는 사람의 ID
+    public let userID: String
+    /// 참가하려는 방의 ID
+    public let roomID: String
     
     public init(from iceCandidate: RTCIceCandidate, userID: String, roomID: String) {
         self.sdpMLineIndex = iceCandidate.sdpMLineIndex

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/SessionDescriptionMessage.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Message/SessionDescriptionMessage.swift
@@ -17,9 +17,12 @@ public enum SdpType: String, Codable {
 public struct SessionDescriptionMessage: Codable {
     public let sdp: String
     public let type: SdpType
-    public let roomID: String // MARK: 참가하려는 방의 ID
-    public let offerID: String // MARK: Offer를 보내는 사람의 ID
-    public let answerID: String? // MARK: Answer를 보내는 사람의 ID
+    /// 참가하려는 방의 ID
+    public let roomID: String
+    /// Offer를 보내는 사람의 ID
+    public let offerID: String
+    /// Answer를 보내는 사람의 ID
+    public let answerID: String?
     
     public init(from rtcSessionDescription: RTCSessionDescription, roomID: String, offerID: String, answerID: String?) {
         self.sdp = rtcSessionDescription.sdp

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Service/SignalingService.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Service/SignalingService.swift
@@ -8,7 +8,7 @@ public protocol SignalingService: WebSocketClientDelegate {
     var didDidDisconnectPublisher: AnyPublisher<Void, Never> { get }
     var didReceiveOfferSdpPublisher: AnyPublisher<SessionDescriptionMessage, Never> { get }
     var didReceiveAnswerSdpPublisher: AnyPublisher<SessionDescriptionMessage, Never> { get }
-    var didReceiveCandidatePublisher: AnyPublisher<RTCIceCandidate, Never> { get }
+    var didReceiveCandidatePublisher: AnyPublisher<IceCandidateMessage, Never> { get }
     
     func connect()
     func send(

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Service/SignalingService.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Service/SignalingService.swift
@@ -22,6 +22,7 @@ public protocol SignalingService: WebSocketClientDelegate {
         type: SignalingRequestDTO.SignalingMessageType,
         candidate: RTCIceCandidate,
         roomID: String,
-        userID: String
+        receiverID: String,
+        senderID: String
     )
 }

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Service/WebRTCService.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/Interface/Service/WebRTCService.swift
@@ -10,6 +10,12 @@ public protocol WebRTCService: RTCPeerConnectionDelegate, RTCDataChannelDelegate
     var peerConnection: RTCPeerConnection { get }
     
     // MARK: SDP
+    func offer() async throws -> RTCSessionDescription
+    func answer() async throws -> RTCSessionDescription
+    func set(remoteSdp: RTCSessionDescription) async throws
+    func set(localSdp: RTCSessionDescription) async throws
+    func set(remoteCandidate: RTCIceCandidate) async throws
+    
     func offer(completion: @escaping (_ sdp: RTCSessionDescription) -> Void)
     func answer(completion: @escaping (_ sdp: RTCSessionDescription) -> Void)
     func set(remoteSdp: RTCSessionDescription, completion: @escaping (Error?) -> Void)

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/SignalingServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/SignalingServiceImpl.swift
@@ -63,9 +63,10 @@ final public class SignalingServiceImpl: SignalingService {
         type: SignalingRequestDTO.SignalingMessageType,
         candidate: RTCIceCandidate,
         roomID: String,
-        userID: String
+        receiverID: String,
+        senderID: String
     ) {
-        let message = IceCandidateMessage(from: candidate, userID: userID, roomID: roomID)
+        let message = IceCandidateMessage(from: candidate, receiverID: receiverID, senderID: senderID, roomID: roomID)
         do {
             let dataMessage = try self.encoder.encode(message)
             let dto = SignalingRequestDTO(messageType: type, message: dataMessage)

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/SignalingServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/SignalingServiceImpl.swift
@@ -12,7 +12,7 @@ final public class SignalingServiceImpl: SignalingService {
     private let didDisconnectSubject = PassthroughSubject<Void, Never>()
     private let didReceiveOfferSdpSubject = PassthroughSubject<SessionDescriptionMessage, Never>()
     private let didReceiveAnswerSdpSubject = PassthroughSubject<SessionDescriptionMessage, Never>()
-    private let didReceiveCandidateSubject = PassthroughSubject<RTCIceCandidate, Never>()
+    private let didReceiveCandidateSubject = PassthroughSubject<IceCandidateMessage, Never>()
     
     public var didConnectPublisher: AnyPublisher<Void, Never> {
         self.didConnectSubject.eraseToAnyPublisher()
@@ -26,7 +26,7 @@ final public class SignalingServiceImpl: SignalingService {
     public var didReceiveAnswerSdpPublisher: AnyPublisher<SessionDescriptionMessage, Never> {
         self.didReceiveAnswerSdpSubject.eraseToAnyPublisher()
     }
-    public var didReceiveCandidatePublisher: AnyPublisher<RTCIceCandidate, Never> {
+    public var didReceiveCandidatePublisher: AnyPublisher<IceCandidateMessage, Never> {
         self.didReceiveCandidateSubject.eraseToAnyPublisher()
     }
     
@@ -99,7 +99,7 @@ extension SignalingServiceImpl {
         case .iceCandidate:
             guard let iceCandidate = response.message?.toDTO(type: IceCandidateMessage.self, decoder: decoder)
             else { return }
-            self.didReceiveCandidateSubject.send(iceCandidate.rtcIceCandidate)
+            self.didReceiveCandidateSubject.send(iceCandidate)
         
         case .offerSDP:
             guard let sdp = response.message?.toDTO(type: SessionDescriptionMessage.self, decoder: decoder)

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/WebRTCServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/WebRTCServiceImpl.swift
@@ -46,6 +46,12 @@ public final class WebRTCServiceImpl: NSObject, WebRTCService {
         config.sdpSemantics = .unifiedPlan
         config.continualGatheringPolicy = .gatherContinually
         
+        let audioConfig = RTCAudioSessionConfiguration.webRTC()
+        audioConfig.category = AVAudioSession.Category.playAndRecord.rawValue
+        audioConfig.mode = AVAudioSession.Mode.voiceChat.rawValue
+        audioConfig.categoryOptions = [.defaultToSpeaker]
+        RTCAudioSessionConfiguration.setWebRTC(audioConfig)
+        
         let constraints = RTCMediaConstraints(
             mandatoryConstraints: nil,
             optionalConstraints: [
@@ -216,6 +222,7 @@ public extension WebRTCServiceImpl {
                 mode: .voiceChat,
                 options: .defaultToSpeaker
             )
+            try self.rtcAudioSession.overrideOutputAudioPort(.speaker)
             try self.rtcAudioSession.setActive(true)
         } catch let error {
             PTGDataLogger.log("Error changeing AVAudioSession category: \(error)")

--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/WebRTCServiceImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ServiceImpl/WebRTCServiceImpl.swift
@@ -74,6 +74,21 @@ public final class WebRTCServiceImpl: NSObject, WebRTCService {
 
 // MARK: SDP
 public extension WebRTCServiceImpl {
+    func offer() async throws -> RTCSessionDescription {
+        let constraints = RTCMediaConstraints(
+            mandatoryConstraints: self.mediaConstraints,
+            optionalConstraints: nil
+        )
+        
+        // 1. constraints를 통해 내 sdp를 만든다.
+        let sdp = try await self.peerConnection.offer(for: constraints)
+        
+        // 2. sdp를 peerConnection에 저장한다음 소켓을 통해 시그널링 서버를 거쳐 상대에게 전송한다.
+        try await self.peerConnection.setLocalDescription(sdp)
+        
+        return sdp
+    }
+    
     func offer(completion: @escaping (_ sdp: RTCSessionDescription) -> Void) {
         let constraints = RTCMediaConstraints(
             mandatoryConstraints: self.mediaConstraints,
@@ -91,6 +106,21 @@ public extension WebRTCServiceImpl {
         }
     }
     
+    func answer() async throws -> RTCSessionDescription {
+        let constraints = RTCMediaConstraints(
+            mandatoryConstraints: self.mediaConstraints,
+            optionalConstraints: nil
+        )
+        
+        // 1. constraints를 통해 내 sdp를 만든다.
+        let sdp = try await self.peerConnection.answer(for: constraints)
+        
+        // 2. sdp를 peerConnection에 저장한다음 소켓을 통해 시그널링 서버를 거쳐 상대에게 전송한다.
+        try await self.peerConnection.setLocalDescription(sdp)
+        
+        return sdp
+    }
+    
     func answer(completion: @escaping (_ sdp: RTCSessionDescription) -> Void) {
         let constraints = RTCMediaConstraints(
             mandatoryConstraints: self.mediaConstraints,
@@ -106,6 +136,18 @@ public extension WebRTCServiceImpl {
                 completion(sdp)
             }
         }
+    }
+    
+    func set(remoteSdp: RTCSessionDescription) async throws {
+        return try await self.peerConnection.setRemoteDescription(remoteSdp)
+    }
+    
+    func set(localSdp: RTCSessionDescription) async throws {
+        return try await self.peerConnection.setLocalDescription(localSdp)
+    }
+    
+    func set(remoteCandidate: RTCIceCandidate) async throws {
+        return try await self.peerConnection.add(remoteCandidate)
     }
     
     func set(remoteSdp: RTCSessionDescription, completion: @escaping (Error?) -> Void) {

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/SendOfferUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/SendOfferUseCaseImpl.swift
@@ -1,9 +1,20 @@
 import Foundation
+import Combine
 import PhotoGetherDomainInterface
 
 public final class SendOfferUseCaseImpl: SendOfferUseCase {
-    public func execute() async throws {
-        try await repository.sendOffer()
+    public func execute() -> AnyPublisher<Void, Error> {
+        Future { promise in
+            Task {
+                do {
+                    try await self.repository.sendOffer()
+                    promise(.success(()))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
     }
     
     private let repository: ConnectionRepository

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/SendOfferUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/SendOfferUseCaseImpl.swift
@@ -2,8 +2,8 @@ import Foundation
 import PhotoGetherDomainInterface
 
 public final class SendOfferUseCaseImpl: SendOfferUseCase {
-    public func execute() -> Bool {
-        repository.sendOffer()
+    public func execute() async throws {
+        try await repository.sendOffer()
     }
     
     private let repository: ConnectionRepository

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/ConnectionClient.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/ConnectionClient.swift
@@ -7,6 +7,7 @@ public protocol ConnectionClient {
     var remoteUserInfo: UserInfo? { get }
     var receivedDataPublisher: PassthroughSubject<Data, Never> { get }
     
+    func createOffer() async throws -> RTCSessionDescription
     func setRemoteUserInfo(_ remoteUserInfo: UserInfo)
     func sendOffer(myID: String)
     func sendData(data: Data)

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/ConnectionClient.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/ConnectionClient.swift
@@ -5,11 +5,18 @@ import Combine
 public protocol ConnectionClient {
     var remoteVideoView: UIView { get }
     var remoteUserInfo: UserInfo? { get }
-    var receivedDataPublisher: PassthroughSubject<Data, Never> { get }
+    
+    var receivedDataPublisher: AnyPublisher<Data, Never> { get }
+    var didGenerateLocalCandidatePublisher: AnyPublisher<(receiverID: String, RTCIceCandidate), Never> { get }
     
     func createOffer() async throws -> RTCSessionDescription
+    func createAnswer() async throws -> RTCSessionDescription
+
+    func set(remoteSdp: RTCSessionDescription) async throws
+    func set(localSdp: RTCSessionDescription) async throws
+    func set(remoteCandidate: RTCIceCandidate) async throws
+    
     func setRemoteUserInfo(_ remoteUserInfo: UserInfo)
-    func sendOffer(myID: String)
     func sendData(data: Data)
     func captureVideo() -> UIImage
     func bindLocalVideo(_ localVideoView: UIView)

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/ConnectionRepository.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/ConnectionRepository.swift
@@ -8,5 +8,5 @@ public protocol ConnectionRepository {
     
     func createRoom() -> AnyPublisher<RoomOwnerEntity, Error>
     func joinRoom(to roomID: String, hostID: String) -> AnyPublisher<Bool, Error>
-    func sendOffer() -> Bool
+    func sendOffer() async throws
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/SendOfferUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/SendOfferUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol SendOfferUseCase {
-    func execute() -> Bool
+    func execute() async throws
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/SendOfferUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/SendOfferUseCase.swift
@@ -1,5 +1,6 @@
 import Foundation
+import Combine
 
 public protocol SendOfferUseCase {
-    func execute() async throws
+    func execute() -> AnyPublisher<Void, Error>
 }

--- a/PhotoGether/PhotoGether/App/SceneDelegate.swift
+++ b/PhotoGether/PhotoGether/App/SceneDelegate.swift
@@ -41,27 +41,25 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
         
         let connectionRepository: ConnectionRepository = ConnectionRepositoryImpl(
+            signlingService: signalingService,
+            roomService: roomService,
             clients: [
                 makeConnectionClient(
-                    signalingService: signalingService,
                     webRTCService: makeWebRTCService(
                         iceServers: stunServers
                     )
                 ),
                 makeConnectionClient(
-                    signalingService: signalingService,
                     webRTCService: makeWebRTCService(
                         iceServers: stunServers
                     )
                 ),
                 makeConnectionClient(
-                    signalingService: signalingService,
                     webRTCService: makeWebRTCService(
                         iceServers: stunServers
                     )
                 )
-            ],
-            roomService: roomService
+            ]
         )
         
         let sendOfferUseCase: SendOfferUseCase = SendOfferUseCaseImpl(
@@ -143,11 +141,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     private func makeConnectionClient(
-        signalingService: SignalingService,
         webRTCService: WebRTCService
     ) -> ConnectionClient {
         return ConnectionClientImpl(
-            signalingService: signalingService,
             webRTCService: webRTCService
         )
     }

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/View/WaitingRoomView.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/View/WaitingRoomView.swift
@@ -1,11 +1,28 @@
 import UIKit
 import DesignSystem
+import BaseFeature
+
+enum ParticipantPosition {
+    case topLeading
+    case topTrailing
+    case bottomLeading
+    case bottomTrailing
+}
 
 final class WaitingRoomView: UIView {
     let bottomBarView = UIView()
     let micButton = PTGMicButton(micState: .on)
     let linkButton = PTGCircleButton(type: .link)
     let startButton = PTGPrimaryButton()
+    
+    private(set) var topLeadingView = UIView()
+    private(set) var topTrailingView = UIView()
+    private(set) var bottomLeadingView = UIView()
+    private(set) var bottomTrailingView = UIView()
+    
+    private let vStackView = UIStackView()
+    private let topHStackView = UIStackView()
+    private let bottomHStackView = UIStackView()
     
     init() {
         super.init(frame: .zero)
@@ -17,6 +34,21 @@ final class WaitingRoomView: UIView {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    func updateParticipantView(view: UIView, position: ParticipantPosition) {
+        switch position {
+        case .topLeading:
+            self.topLeadingView.addSubview(view)
+        case .topTrailing:
+            self.topTrailingView.addSubview(view)
+        case .bottomLeading:
+            self.bottomLeadingView.addSubview(view)
+        case .bottomTrailing:
+            self.bottomTrailingView.addSubview(view)
+        }
+        view.clipsToBounds = true
+        view.snp.makeConstraints { $0.edges.equalToSuperview() }
     }
     
     func toggleMicButtonState() {
@@ -31,13 +63,26 @@ final class WaitingRoomView: UIView {
 
 private extension WaitingRoomView {
     func addViews() {
-        [bottomBarView, micButton].forEach { addSubview($0) }
-        [linkButton, startButton].forEach {
-            bottomBarView.addSubview($0)
-        }
+        [bottomBarView, micButton, vStackView].forEach { addSubview($0) }
+        [linkButton, startButton].forEach { bottomBarView.addSubview($0) }
+        
+        [topLeadingView, topTrailingView].forEach { topHStackView.addArrangedSubview($0) }
+        [bottomLeadingView, bottomTrailingView].forEach { bottomHStackView.addArrangedSubview($0) }
+        [topHStackView, bottomHStackView].forEach { vStackView.addArrangedSubview($0) }
     }
     
     func setConstraints() {
+        let horizontalSpacing = Constants.sectionHorizontalSpacing * 2
+        let itemWidth = (UIScreen.main.bounds.width - horizontalSpacing - Constants.itemSpacing) / 2
+        let itemHeight = itemWidth * Constants.sizeMultiplier
+        let topOffset: CGFloat = APP_HEIGHT() > 667 ? 44 : 0 // 최소사이즈 기기 SE2 기준
+        
+        vStackView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(topOffset)
+            $0.horizontalEdges.equalToSuperview().inset(Constants.sectionHorizontalSpacing)
+            $0.bottom.equalTo(bottomBarView.snp.top)
+        }
+        
         bottomBarView.snp.makeConstraints {
             $0.height.equalTo(Constants.bottomBarViewHeight)
             $0.horizontalEdges.equalToSuperview()
@@ -70,6 +115,22 @@ private extension WaitingRoomView {
     func configureUI() {
         self.backgroundColor = PTGColor.gray90.color
         
+        vStackView.axis = .vertical
+        vStackView.spacing = Constants.itemSpacing
+        vStackView.distribution = .fillEqually
+        
+        [topHStackView, bottomHStackView].forEach {
+            $0.axis = .horizontal
+            $0.spacing = Constants.itemSpacing
+            $0.distribution = .fillEqually
+        }
+        
+        [topLeadingView,
+        topTrailingView,
+        bottomLeadingView,
+         bottomTrailingView
+        ].forEach { $0.backgroundColor = PTGColor.gray50.color }
+
         startButton.setTitle(to: StartButtonTitle.one.rawValue)
     }
 }
@@ -98,5 +159,9 @@ extension WaitingRoomView {
         static let circleButtonSize: CGSize = CGSize(width: 52, height: 52)
         static let startButtonHeight: CGFloat = 52
         static let micButtonBottomSpacing: CGFloat = -4
+        
+        static let sizeMultiplier: CGFloat = 290 / 179 // 피그마 디자인에 따른 세로/가로 비율입니다.
+        static let sectionHorizontalSpacing: CGFloat = 12
+        static let itemSpacing: CGFloat = 11
     }
 }

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/WaitingRoomViewController.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/WaitingRoomViewController.swift
@@ -102,7 +102,7 @@ public final class WaitingRoomViewController: BaseViewController {
     }
 
     private func navigateToPhotoRoom() {
-        let collectionVC = participantsCollectionViewController
+        let collectionVC = ParticipantsCollectionViewController()
         let photoRoomVC = photoRoomViewController
         photoRoomVC.setCollectionViewController(collectionVC)
         navigationController?.pushViewController(photoRoomVC, animated: true)

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/WaitingRoomViewController.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/WaitingRoomViewController.swift
@@ -8,7 +8,6 @@ import PhotoGetherDomainInterface
 public final class WaitingRoomViewController: BaseViewController {
     private let viewModel: WaitingRoomViewModel
     private let waitingRoomView = WaitingRoomView()
-    private let participantsCollectionViewController = ParticipantsCollectionViewController()
     private let photoRoomViewController: PhotoRoomViewController
     
     private let viewDidLoadSubject = PassthroughSubject<Void, Never>()
@@ -36,37 +35,10 @@ public final class WaitingRoomViewController: BaseViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         defer { viewDidLoadSubject.send(()) }
-        addViews()
-        setupConstraints()
-        configureUI()
-        setPlaceHolder()
         bindInput()
         bindOutput()
     }
     
-    private func addViews() {
-        addChild(participantsCollectionViewController)
-        participantsCollectionViewController.didMove(toParent: self)
-        
-        let collectionView = participantsCollectionViewController.view ?? UIView()
-        let micButton = waitingRoomView.micButton
-        waitingRoomView.insertSubview(collectionView, belowSubview: micButton)
-    }
-    
-    private func setupConstraints() {
-        let collectionView = participantsCollectionViewController.view ?? UIView()
-        let topOffset: CGFloat = APP_HEIGHT() > 667 ? 44 : 0 // 최소사이즈 기기 SE2 기준
-        collectionView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(topOffset)
-            $0.bottom.equalTo(waitingRoomView.bottomBarView.snp.top)
-            $0.horizontalEdges.equalToSuperview()
-        }
-    }
-    
-    private func configureUI() {
-        participantsCollectionViewController.collectionView.backgroundColor = PTGColor.gray90.color
-    }
-
     private func bindInput() {
         viewDidLoadSubject.sink { [weak self] _ in
             self?.input.send(.viewDidLoad)
@@ -92,31 +64,28 @@ public final class WaitingRoomViewController: BaseViewController {
     private func bindOutput() {
         let output = viewModel.transform(input: input.eraseToAnyPublisher())
         
-        output
-            .sink { [weak self] in
+        output.sink { [weak self] in
             guard let self else { return }
             switch $0 {
-                
             // MARK: 네비게이션 처리
             case .navigateToPhotoRoom:
                 self.navigateToPhotoRoom()
                 
             // MARK: 내 비디오 화면 업데이트
             case .localVideo(let localVideoView):
-                self.updateParticipantView(
-                    position: .host,
-                    nickname: "나는 호스트",
-                    videoView: localVideoView
-                )
+                print(localVideoView)
+                self.waitingRoomView.updateParticipantView(view: localVideoView, position: .topLeading)
                 
             // MARK: 상대방 비디오 화면 업데이트
             case .remoteVideos(let remoteVideoViews):
-                guard let remoteVideoView = remoteVideoViews.first else { return }
-                self.updateParticipantView(
-                    position: .guest3,
-                    nickname: "나는 게스트",
-                    videoView: remoteVideoView
-                )
+                let guest1 = remoteVideoViews[safe: 0] ?? UIView()
+                let guest2 = remoteVideoViews[safe: 1] ?? UIView()
+                let guest3 = remoteVideoViews[safe: 2] ?? UIView()
+                
+                self.waitingRoomView.updateParticipantView(view: guest1, position: .topTrailing)
+                self.waitingRoomView.updateParticipantView(view: guest2, position: .bottomLeading)
+                self.waitingRoomView.updateParticipantView(view: guest3, position: .bottomTrailing)
+
             // MARK: 마이크 음소거 UI 업데이트
             case .micMuteState:
                 return
@@ -137,40 +106,6 @@ public final class WaitingRoomViewController: BaseViewController {
         let photoRoomVC = photoRoomViewController
         photoRoomVC.setCollectionViewController(collectionVC)
         navigationController?.pushViewController(photoRoomVC, animated: true)
-    }
-
-    private func updateParticipantView(
-        position: ParticipantsSectionItem.Position,
-        nickname: String,
-        videoView: UIView
-    ) {
-        var snapshot = participantsCollectionViewController.dataSource.snapshot()
-        var items = snapshot.itemIdentifiers
-        
-        guard let index = items.firstIndex(where: { $0.position == position }) else { return }
-        
-        let newItem = SectionItem(position: position, nickname: nickname, videoView: videoView)
-        
-        items.remove(at: index)
-        items.insert(newItem, at: index)
-        
-        snapshot.deleteItems(items)
-        snapshot.appendItems(items, toSection: 0)
-        
-        participantsCollectionViewController.dataSource.apply(snapshot, animatingDifferences: true)
-    }
-    
-    private func setPlaceHolder() {
-        let placeHolder = [
-            ParticipantsSectionItem(position: .host, nickname: "host"),
-            ParticipantsSectionItem(position: .guest1, nickname: "guest1"),
-            ParticipantsSectionItem(position: .guest2, nickname: "guest2"),
-            ParticipantsSectionItem(position: .guest3, nickname: "guest3")
-        ]
-        var snapshot = participantsCollectionViewController.dataSource.snapshot()
-        snapshot.appendSections([0])
-        snapshot.appendItems(placeHolder, toSection: 0)
-        participantsCollectionViewController.dataSource.apply(snapshot, animatingDifferences: true)
     }
     
     private func showShareSheet(message: String) {

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewModel/WaitingRoomViewModel.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewModel/WaitingRoomViewModel.swift
@@ -71,8 +71,14 @@ public final class WaitingRoomViewModel {
         output.send(.remoteVideos(remoteVideos))
         
         if !isHost {
-            let message = sendOfferUseCase.execute() ? "연결을 시도합니다." : "연결 중 에러가 발생했어요."
-            output.send(.shouldShowToast(message))
+            Task {
+                do {
+                    try await sendOfferUseCase.execute()
+                    output.send(.shouldShowToast("연결을 시도합니다."))
+                } catch {
+                    output.send(.shouldShowToast("연결 중 에러가 발생했어요."))
+                }
+            }
         }
     }
     

--- a/PhotoGetherServer/PhotoGetherServer/Sources/App/DTO/Message/IceCandidateMessage.swift
+++ b/PhotoGetherServer/PhotoGetherServer/Sources/App/DTO/Message/IceCandidateMessage.swift
@@ -4,14 +4,16 @@ package struct IceCandidateMessage: Codable {
     let sdp: String
     let sdpMLineIndex: Int32
     let sdpMid: String?
-    let userID: String // MARK: 받는 사람의 ID
+    let receiverID: String // MARK: 받는 사람의 ID
+    let senderID: String // MARK: 보내는 사람의 ID
     let roomID: String // MARK: 참가하려는 방의 ID
     
-    package init(sdp: String, sdpMLineIndex: Int32, sdpMid: String?, userID: String, roomID: String) {
+    package init(sdp: String, sdpMLineIndex: Int32, sdpMid: String?, receiverID: String, senderID: String, roomID: String) {
         self.sdp = sdp
         self.sdpMLineIndex = sdpMLineIndex
         self.sdpMid = sdpMid
-        self.userID = userID
+        self.receiverID = receiverID
+        self.senderID = senderID
         self.roomID = roomID
     }
 }

--- a/PhotoGetherServer/PhotoGetherServer/Sources/App/Model/RoomManager.swift
+++ b/PhotoGetherServer/PhotoGetherServer/Sources/App/Model/RoomManager.swift
@@ -103,8 +103,8 @@ actor RoomManager {
             return
         }
         
-        guard let targetUser = targetRoom.userList.filter({ $0.id == dto.userID }).first else {
-            print("[DEBUG] :: Failed To Find User\(dto.userID)")
+        guard let targetUser = targetRoom.userList.filter({ $0.id == dto.receiverID }).first else {
+            print("[DEBUG] :: Failed To Find User\(dto.receiverID)")
             return
         }
         let response = SignalingResponseDTO(

--- a/PhotoGetherServer/PhotoGetherServer/Sources/App/Model/RoomManager.swift
+++ b/PhotoGetherServer/PhotoGetherServer/Sources/App/Model/RoomManager.swift
@@ -63,20 +63,18 @@ actor RoomManager {
             print("[DEBUG] :: Failed To Find Room\(dto.roomID)")
             return
         }
-        
-        let targetList = targetRoom.userList.filter { $0.id != dto.offerID }
-        
-        targetList.forEach {
-            var responseDTO = dto
-            responseDTO.answerID = $0.id
-            
-            let response = SignalingResponseDTO(
-                messageType: .offerSDP,
-                message: responseDTO.toData(encoder)
-            )
-            
-            $0.client.sendDTO(response, encoder: encoder)
+
+        guard let receiver = targetRoom.userList.first(where: { $0.id == dto.answerID }) else {
+            print("[DEBUG] :: not found receiver for offerSDP in room \(dto.roomID) \(dto.answerID ?? "nil")")
+            return
         }
+        
+        let response = SignalingResponseDTO(
+            messageType: .offerSDP,
+            message: dto.toData(encoder)
+        )
+        
+        receiver.client.sendDTO(response, encoder: encoder)
     }
     
     func sendAnswerSDP(dto: SessionDescriptionMessage) async {
@@ -85,16 +83,17 @@ actor RoomManager {
             return
         }
         
-        guard let targetUser = targetRoom.userList.filter({ $0.id == dto.offerID }).first else {
-            print("[DEBUG] :: Failed To Find User\(dto.offerID)")
+        guard let receiver = targetRoom.userList.first(where: { $0.id == dto.offerID }) else {
+            print("[DEBUG] :: not found receiver for answerSDP in room \(dto.roomID) \(dto.offerID)")
             return
         }
+        
         let response = SignalingResponseDTO(
             messageType: .answerSDP,
             message: dto.toData(encoder)
         )
         
-        targetUser.client.sendDTO(response, encoder: encoder)
+        receiver.client.sendDTO(response, encoder: encoder)
     }
     
     func sendIceCandidate(dto: IceCandidateMessage) async {
@@ -103,7 +102,7 @@ actor RoomManager {
             return
         }
         
-        guard let targetUser = targetRoom.userList.filter({ $0.id == dto.receiverID }).first else {
+        guard let receiver = targetRoom.userList.first(where: { $0.id == dto.receiverID }) else {
             print("[DEBUG] :: Failed To Find User\(dto.receiverID)")
             return
         }
@@ -112,7 +111,7 @@ actor RoomManager {
             message: dto.toData(encoder)
         )
         
-        targetUser.client.sendDTO(response, encoder: encoder)
+        receiver.client.sendDTO(response, encoder: encoder)
     }
     
     

--- a/PhotoGetherServer/PhotoGetherServer/Sources/App/Utils/WebSocket+decodeDTO.swift
+++ b/PhotoGetherServer/PhotoGetherServer/Sources/App/Utils/WebSocket+decodeDTO.swift
@@ -7,7 +7,7 @@ extension WebSocket {
         decoder: JSONDecoder
     ) -> T? {
         guard let dto = data.toDTO(type: type, decoder: decoder) else {
-            print("[DEBUG] :: Decode Failed: \(type) \(data)")
+            print("[DEBUG] :: Decode Failed: \(type) \(data.readableBytes)")
             return nil
         }
         return dto
@@ -19,7 +19,7 @@ extension WebSocket {
         decoder: JSONDecoder
     ) -> T? {
         guard let dto = data.toDTO(type: type, decoder: decoder) else {
-            print("[DEBUG] :: Decode Failed: \(type) \(data)")
+            print("[DEBUG] :: Decode Failed: \(type) \(data.count)")
             return nil
         }
         return dto

--- a/PhotoGetherServer/PhotoGetherServer/Sources/App/Utils/WebSocket+sendDTO.swift
+++ b/PhotoGetherServer/PhotoGetherServer/Sources/App/Utils/WebSocket+sendDTO.swift
@@ -7,7 +7,7 @@ extension WebSocket {
         encoder: JSONEncoder
     ) -> Bool {
         guard let data = dto.toData(encoder) else {
-            print("[DEBUG] :: Encode Failed: \(dto)")
+            print("[DEBUG] :: Encode Failed: \(dto.self)")
             return false
         }
         self.send(data)


### PR DESCRIPTION
## 🤔 배경
> [!IMPORTANT]
>2명까지는 연결이 되지만 3인부터는 연결이 안되는 문제가 발생했습니다.
>개발 마감이 얼마남지않아 긴급 수정하게 되었습니다.

## 📃 작업 내역
### 서버 offerSDP 로직 수정
로그 분석을 통해 이중으로 offer를 보내고 있던 문제점을 발견할 수 있었습니다. 예전 아이디어의 로직이 그대로 남아있던 문제였습니다.


### SignalingService를 ConnectionRepository에서 들고있도록 변경
ConnectionClient마다 SignalingService를 들고 있어, 로그가 무수히 많이 찍혔고 로직 관리에 어려움이 많았습니다.
그래서 ConnectionRepository에서 시그널링 이벤트를 처리해 알맞는 ConnectionClient에게 전달하는 방식으로 변경했습니다.

변경 전

<img width="80%" alt="image" src="https://github.com/user-attachments/assets/e0a50534-55a8-4576-af5a-b12daee7ae32">

변경 후

<img width="80%" alt="image" src="https://github.com/user-attachments/assets/26f56422-b948-4301-bbb3-122c5634c860">


### 유저 간 음성 출력 위치를 스피커로 변경
기존엔 상단 스피커를 통해 음성이 출력되었고 소리가 작았습니다. 기본 설정을 하단 스피커 출력으로 변경해 사용자간 원활한 대화를 할 수 있도록 변경했습니다.

## ✅ 리뷰 노트
긴급 건이라 빠른 리뷰 부탁드립니다.

## 🚀 테스트 방법
> [!NOTE]
> 1. Secrets.xcconfig 에서 BASE_URL의 endpoint를 /signaling으로 변경합니다.
> 2. 앱을 켜고 진입해 좌측 하단 링크 버튼 클릭
> 3. 딥링크 URI 공유
> 4. 딥링크를 통해 앱에 접속
> 5. 연결 완료

