### PR TITLE
[FIX/#146] 캡쳐 로직 수정 및 최적화

### DIFF
--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/CapturableVideoView.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/CapturableVideoView.swift
@@ -1,21 +1,30 @@
 import Foundation
+import CoreGraphics
 import WebRTC
 
 public class CapturableVideoView: RTCMTLVideoView {
-    public var capturedImage: UIImage?
-
+    private var capturedCGImage: CGImage?
+    
+    public var capturedImage: UIImage? {
+        guard let capturedCGImage,
+              let flipedImage = flipCgImageHorizontally(cgImage: capturedCGImage)
+        else { return nil }
+        
+        return UIImage(cgImage: flipedImage)
+    }
+    
     public override func setSize(_ size: CGSize) {
         super.setSize(size)
     }
-
+    
     public override func renderFrame(_ frame: RTCVideoFrame?) {
         guard let frame = frame else { return }
         
         super.renderFrame(frame)
-        capturedImage = convertFrameToImage(frame)
+        capturedCGImage = convertFrameToImage(frame)
     }
-
-    private func convertFrameToImage(_ frame: RTCVideoFrame) -> UIImage? {
+    
+    private func convertFrameToImage(_ frame: RTCVideoFrame) -> CGImage? {
         // frame의 버퍼를 CVPixelBuffer로 가져옴
         guard let pixelBuffer = (frame.buffer as? RTCCVPixelBuffer)?.pixelBuffer else { return nil }
         
@@ -24,9 +33,36 @@ public class CapturableVideoView: RTCMTLVideoView {
         
         // CIImage를 UIImage로 변환
         let context = CIContext(options: nil)
+        
         if let cgImage = context.createCGImage(ciImage, from: ciImage.extent) {
-            return UIImage(cgImage: cgImage)
+            return cgImage
         }
         return nil
+    }
+    
+    private func flipCgImageHorizontally(cgImage: CGImage) -> CGImage? {
+        let width = cgImage.width
+        let height = cgImage.height
+        
+        // 비트맵 컨텍스트 생성
+        guard let colorSpace = cgImage.colorSpace,
+              let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: cgImage.bitsPerComponent,
+                bytesPerRow: cgImage.bytesPerRow,
+                space: colorSpace,
+                bitmapInfo: cgImage.bitmapInfo.rawValue
+              ) else {
+            return nil
+        }
+        
+        context.translateBy(x: CGFloat(width), y: 0)
+        context.scaleBy(x: -1, y: 1)
+        
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height)))
+        
+        return context.makeImage()
     }
 }


### PR DESCRIPTION
## 🤔 배경
- 촬영 전 화면은 좌우반전이 적용됐는데 촬영된 이미지는 좌우반전이 적용이 안되어 있는 점 해결
- 영상 프레임 단위의 UIImage 렌더링이 일어나는 것이 성능 상 문제될 것으로 예상됨

## 📃 작업 내역
- [ ] 좌우 반전 적용
- [ ] 영상 프레임 캡쳐 성능 향상

## ✅ 리뷰 노트
1. 영상 화면이 renderFrame을 매 프레임 호출할때마다 UIImage로 매 프레임을 렌더링해서 보관하는 부분이 성능 상 문제될 것이라고 생각하여 매 프레임 저장은 CGImage로 하고 UIImage로 렌더링은 외부에서 호출할 때 시점에 일어나도록 했습니다. 
```swift
private var capturedCGImage: CGImage?

public var capturedImage: UIImage? {
    guard let capturedCGImage,
          let flipedImage = flipCgImageHorizontally(cgImage: capturedCGImage)
    else { return nil }

    return UIImage(cgImage: flipedImage)
}
```

## 🎨 스크린샷
| iPhone SE(2세대) | iPhone 14 | iPhone 16 Pro Max |
| -------------- | -------------- | -------------- |
| 스샷 | 스샷 | 스샷 |


## 🚀 테스트 방법

