### PR TITLE
[FEAT/#148] 스티커 사이즈 조절 기능 추가

### DIFF
--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/CanvasScrollView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/CanvasScrollView.swift
@@ -10,6 +10,9 @@ protocol CanvasScrollViewDelegate: AnyObject {
     func canvasScrollView(_ canvasScrollView: CanvasScrollView, didBeginDrag sticker: StickerEntity)
     func canvasScrollView(_ canvasScrollView: CanvasScrollView, didChangeDrag sticker: StickerEntity)
     func canvasScrollView(_ canvasScrollView: CanvasScrollView, didEndDrag sticker: StickerEntity)
+    func canvasScrollView(_ canvasScrollView: CanvasScrollView, didBeginResize sticker: StickerEntity)
+    func canvasScrollView(_ canvasScrollView: CanvasScrollView, didChangeResize sticker: StickerEntity)
+    func canvasScrollView(_ canvasScrollView: CanvasScrollView, didEndResize sticker: StickerEntity)
 }
 
 final class CanvasScrollView: UIScrollView {
@@ -196,5 +199,17 @@ extension CanvasScrollView: StickerViewActionDelegate {
     
     func stickerView(_ stickerView: StickerView, didEndDrag sticker: StickerEntity) {
         canvasScrollViewDelegate?.canvasScrollView(self, didEndDrag: sticker)
+    }
+    
+    func stickerView(_ stickerView: StickerView, willBeginResizing sticker: StickerEntity) {
+        canvasScrollViewDelegate?.canvasScrollView(self, didBeginResize: sticker)
+    }
+    
+    func stickerView(_ stickerView: StickerView, didResize sticker: StickerEntity) {
+        canvasScrollViewDelegate?.canvasScrollView(self, didChangeResize: sticker)
+    }
+    
+    func stickerView(_ stickerView: StickerView, didEndResize sticker: StickerEntity) {
+        canvasScrollViewDelegate?.canvasScrollView(self, didEndResize: sticker)
     }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/CanvasScrollView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/CanvasScrollView.swift
@@ -40,7 +40,7 @@ final class CanvasScrollView: UIScrollView {
     
     private func configureUI() {
         isScrollEnabled = true
-        maximumZoomScale = 3
+        maximumZoomScale = 2
         bouncesZoom = true
         showsHorizontalScrollIndicator = false
         showsVerticalScrollIndicator = false

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
@@ -186,4 +186,16 @@ extension EditPhotoRoomGuestViewController: CanvasScrollViewDelegate {
     func canvasScrollView(_ canvasScrollView: CanvasScrollView, didEndDrag sticker: StickerEntity) {
         input.send(.dragSticker(sticker, .ended))
     }
+    
+    func canvasScrollView(_ canvasScrollView: CanvasScrollView, didBeginResize sticker: StickerEntity) {
+        input.send(.resizeSticker(sticker, .began))
+    }
+    
+    func canvasScrollView(_ canvasScrollView: CanvasScrollView, didChangeResize sticker: StickerEntity) {
+        input.send(.resizeSticker(sticker, .changed))
+    }
+    
+    func canvasScrollView(_ canvasScrollView: CanvasScrollView, didEndResize sticker: StickerEntity) {
+        input.send(.resizeSticker(sticker, .ended))
+    }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewController.swift
@@ -118,7 +118,7 @@ public class EditPhotoRoomGuestViewController: BaseViewController, ViewControlle
     }
     
     private func createStickerEntity(by entity: EmojiEntity) {
-        let imageSize: CGFloat = 64
+        let imageSize: CGFloat = 72
         let frame = calculateCenterPosition(imageSize: imageSize)
         
         let newSticker = StickerEntity(

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -10,7 +10,8 @@ public final class EditPhotoRoomGuestViewModel {
         case frameButtonDidTap
         case createSticker(StickerEntity)
         case deleteSticker(UUID)
-        case dragSticker(StickerEntity, DragState)
+        case dragSticker(StickerEntity, PanGestureState)
+        case resizeSticker(StickerEntity, PanGestureState)
         case stickerViewDidTap(UUID)
     }
     
@@ -99,6 +100,8 @@ public final class EditPhotoRoomGuestViewModel {
                 self?.handleStickerViewDidTap(with: stickerID)
             case .dragSticker(let sticker, let dragState):
                 self?.handleDragSticker(sticker: sticker, state: dragState)
+            case .resizeSticker(let sticker, let resizeState):
+                self?.handleResizeSticker(sticker: sticker, state: resizeState)
             }
         }
         .store(in: &cancellables)
@@ -196,6 +199,29 @@ extension EditPhotoRoomGuestViewModel {
         guard canInteractWithSticker(id: sticker.id) else { return }
         
         mutateStickerEventHub(type: .update, with: sticker)
+    }
+}
+
+// MARK: Sticker Resize
+extension EditPhotoRoomGuestViewModel {
+    private func handleResizeSticker(sticker: StickerEntity, state: PanGestureState) {
+        switch state {
+        case .began:
+            handleResizeBegan(sticker: sticker)
+        case .changed:
+            handleResizeChanged(sticker: sticker)
+        case .ended:
+            handleResizeEnded(sticker: sticker)
+        }
+    }
+    
+    private func handleResizeBegan(sticker: StickerEntity) {
+    }
+    
+    private func handleResizeChanged(sticker: StickerEntity) {
+    }
+    
+    private func handleResizeEnded(sticker: StickerEntity) {
     }
 }
 

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -216,12 +216,23 @@ extension EditPhotoRoomGuestViewModel {
     }
     
     private func handleResizeBegan(sticker: StickerEntity) {
+        guard canInteractWithSticker(id: sticker.id) else { return }
+        
+        mutateStickerEventHub(type: .update, with: sticker)
     }
     
     private func handleResizeChanged(sticker: StickerEntity) {
+        guard canInteractWithSticker(id: sticker.id) else { return }
+        
+        mutateStickerEventHub(type: .update, with: sticker)
     }
     
     private func handleResizeEnded(sticker: StickerEntity) {
+        mutateStickerLocal(type: .update, sticker: sticker)
+        
+        guard canInteractWithSticker(id: sticker.id) else { return }
+        
+        mutateStickerEventHub(type: .update, with: sticker)
     }
 }
 

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomGuestViewModel.swift
@@ -112,6 +112,12 @@ public final class EditPhotoRoomGuestViewModel {
 
 // MARK: Sticker
 extension EditPhotoRoomGuestViewModel {
+    enum PanGestureState {
+        case began
+        case changed
+        case ended
+    }
+    
     private func mutateStickerLocal(type: EventType, sticker: StickerEntity) {
         switch type {
         case .create:
@@ -162,13 +168,7 @@ extension EditPhotoRoomGuestViewModel {
 
 // MARK: Sticker Drag
 extension EditPhotoRoomGuestViewModel {
-    enum DragState {
-        case began
-        case changed
-        case ended
-    }
-    
-    private func handleDragSticker(sticker: StickerEntity, state: DragState) {
+    private func handleDragSticker(sticker: StickerEntity, state: PanGestureState) {
         switch state {
         case .began:
             handleDragBegan(sticker: sticker)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -182,28 +182,6 @@ extension EditPhotoRoomHostViewController: StickerBottomSheetViewControllerDeleg
     }
 }
 
-extension EditPhotoRoomHostViewController: StickerViewActionDelegate {
-    func stickerView(_ stickerView: StickerView, willBeginDraging sticker: PhotoGetherDomainInterface.StickerEntity) {
-         
-    }
-    
-    func stickerView(_ stickerView: StickerView, didDrag sticker: PhotoGetherDomainInterface.StickerEntity) {
-         
-    }
-    
-    func stickerView(_ stickerView: StickerView, didEndDrag sticker: PhotoGetherDomainInterface.StickerEntity) {
-         
-    }
-    
-    func stickerView(_ stickerView: StickerView, didTap id: UUID) {
-        input.send(.stickerViewDidTap(id))
-    }
-    
-    func stickerView(_ stickerView: StickerView, didTapDelete id: UUID) {
-        input.send(.deleteSticker(id))
-    }
-}
-
 extension EditPhotoRoomHostViewController: CanvasScrollViewDelegate {
     func canvasScrollView(_ canvasScrollView: CanvasScrollView, didTap id: UUID) {
         input.send(.stickerViewDidTap(id))

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -228,4 +228,16 @@ extension EditPhotoRoomHostViewController: CanvasScrollViewDelegate {
     func canvasScrollView(_ canvasScrollView: CanvasScrollView, didEndDrag sticker: StickerEntity) {
         input.send(.dragSticker(sticker, .ended))
     }
+    
+    func canvasScrollView(_ canvasScrollView: CanvasScrollView, didBeginResize sticker: StickerEntity) {
+        input.send(.resizeSticker(sticker, .began))
+    }
+    
+    func canvasScrollView(_ canvasScrollView: CanvasScrollView, didChangeResize sticker: StickerEntity) {
+        input.send(.resizeSticker(sticker, .changed))
+    }
+    
+    func canvasScrollView(_ canvasScrollView: CanvasScrollView, didEndResize sticker: StickerEntity) {
+        input.send(.resizeSticker(sticker, .ended))
+    }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -138,7 +138,7 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
     }
     
     private func createStickerEntity(by entity: EmojiEntity) {
-        let imageSize: CGFloat = 64
+        let imageSize: CGFloat = 72
         let frame = calculateCenterPosition(imageSize: imageSize)
         
         let newSticker = StickerEntity(

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -113,6 +113,12 @@ public final class EditPhotoRoomHostViewModel {
 
 // MARK: Sticker
 extension EditPhotoRoomHostViewModel {
+    enum PanGestureState {
+        case began
+        case changed
+        case ended
+    }
+    
     private func mutateStickerLocal(type: EventType, sticker: StickerEntity) {
         switch type {
         case .create:
@@ -163,13 +169,7 @@ extension EditPhotoRoomHostViewModel {
 
 // MARK: Sticker Drag
 extension EditPhotoRoomHostViewModel {
-    enum DragState {
-        case began
-        case changed
-        case ended
-    }
-    
-    private func handleDragSticker(sticker: StickerEntity, state: DragState) {
+    private func handleDragSticker(sticker: StickerEntity, state: PanGestureState) {
         switch state {
         case .began:
             handleDragBegan(sticker: sticker)

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -217,12 +217,23 @@ extension EditPhotoRoomHostViewModel {
     }
     
     private func handleResizeBegan(sticker: StickerEntity) {
+        guard canInteractWithSticker(id: sticker.id) else { return }
+        
+        mutateStickerEventHub(type: .update, with: sticker)
     }
     
     private func handleResizeChanged(sticker: StickerEntity) {
+        guard canInteractWithSticker(id: sticker.id) else { return }
+        
+        mutateStickerEventHub(type: .update, with: sticker)
     }
     
     private func handleResizeEnded(sticker: StickerEntity) {
+        mutateStickerLocal(type: .update, sticker: sticker)
+        
+        guard canInteractWithSticker(id: sticker.id) else { return }
+        
+        mutateStickerEventHub(type: .update, with: sticker)
     }
 }
 

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewModel.swift
@@ -10,7 +10,8 @@ public final class EditPhotoRoomHostViewModel {
         case frameButtonDidTap
         case createSticker(StickerEntity)
         case deleteSticker(UUID)
-        case dragSticker(StickerEntity, DragState)
+        case dragSticker(StickerEntity, PanGestureState)
+        case resizeSticker(StickerEntity, PanGestureState)
         case stickerViewDidTap(UUID)
     }
     
@@ -100,6 +101,8 @@ public final class EditPhotoRoomHostViewModel {
                 self?.handleStickerViewDidTap(with: stickerID)
             case .dragSticker(let sticker, let dragState):
                 self?.handleDragSticker(sticker: sticker, state: dragState)
+            case .resizeSticker(let sticker, let resizeState):
+                self?.handleResizeSticker(sticker: sticker, state: resizeState)
             }
         }
         .store(in: &cancellables)
@@ -197,6 +200,29 @@ extension EditPhotoRoomHostViewModel {
         guard canInteractWithSticker(id: sticker.id) else { return }
         
         mutateStickerEventHub(type: .update, with: sticker)
+    }
+}
+
+// MARK: Sticker Resize
+extension EditPhotoRoomHostViewModel {
+    private func handleResizeSticker(sticker: StickerEntity, state: PanGestureState) {
+        switch state {
+        case .began:
+            handleResizeBegan(sticker: sticker)
+        case .changed:
+            handleResizeChanged(sticker: sticker)
+        case .ended:
+            handleResizeEnded(sticker: sticker)
+        }
+    }
+    
+    private func handleResizeBegan(sticker: StickerEntity) {
+    }
+    
+    private func handleResizeChanged(sticker: StickerEntity) {
+    }
+    
+    private func handleResizeEnded(sticker: StickerEntity) {
     }
 }
 

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
@@ -17,6 +17,7 @@ final class StickerView: UIView {
     private let deleteButton = UIButton()
     private let resizeButton = UIButton()
     private let panGestureRecognizer = UIPanGestureRecognizer()
+    private let resizePanGestureRecognizer = UIPanGestureRecognizer()
 
     private var sticker: StickerEntity
     private let user: String
@@ -102,8 +103,11 @@ final class StickerView: UIView {
         
         panGestureRecognizer.minimumNumberOfTouches = 1
         panGestureRecognizer.addTarget(self, action: #selector(handlePanGesture))
-        
         addGestureRecognizer(panGestureRecognizer)
+        
+        resizePanGestureRecognizer.minimumNumberOfTouches = 1
+        resizePanGestureRecognizer.addTarget(self, action: #selector(handleResizePanGesture))
+        resizeButton.addGestureRecognizer(resizePanGestureRecognizer)
     }
     
     @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
@@ -127,6 +131,31 @@ final class StickerView: UIView {
             delegate?.stickerView(self, didDrag: sticker)
         case .ended:
             delegate?.stickerView(self, didEndDrag: sticker)
+        default: break
+        }
+    }
+    
+    @objc private func handleResizePanGesture(_ gesture: UIPanGestureRecognizer) {
+        let initialSize = sticker.frame.size
+        let translationPoint = gesture.translation(in: self)
+        let delta = min(translationPoint.x, translationPoint.y)
+        let changedWidth = min(128, max(initialSize.width + delta, 48))
+        let changedHeight = changedWidth
+        let traslationStickerSize = CGSize(width: changedWidth, height: changedHeight)
+        
+        resizePanGestureRecognizer.setTranslation(.zero, in: resizeButton)
+        let newFrame = CGRect(origin: sticker.frame.origin, size: traslationStickerSize)
+        
+        switch gesture.state {
+        case .began:
+            updateFrame(to: newFrame)
+//            delegate?.stickerView(self, willBeginDraging: sticker)
+        case .changed:
+            updateFrame(to: newFrame)
+//            delegate?.stickerView(self, didDrag: sticker)
+        case .ended:
+            break
+//            delegate?.stickerView(self, didEndDrag: sticker)
         default: break
         }
     }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
@@ -16,7 +16,7 @@ final class StickerView: UIView {
     private let layerView = UIView()
     private let deleteButton = UIButton()
     private let resizeButton = UIButton()
-    private let panGestureRecognizer = UIPanGestureRecognizer()
+    private let dragPanGestureRecognizer = UIPanGestureRecognizer()
     private let resizePanGestureRecognizer = UIPanGestureRecognizer()
 
     private var sticker: StickerEntity
@@ -101,23 +101,23 @@ final class StickerView: UIView {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
         addGestureRecognizer(tapGesture)
         
-        panGestureRecognizer.minimumNumberOfTouches = 1
-        panGestureRecognizer.addTarget(self, action: #selector(handlePanGesture))
-        addGestureRecognizer(panGestureRecognizer)
+        dragPanGestureRecognizer.minimumNumberOfTouches = 1
+        dragPanGestureRecognizer.addTarget(self, action: #selector(handleDragPanGesture))
+        addGestureRecognizer(dragPanGestureRecognizer)
         
         resizePanGestureRecognizer.minimumNumberOfTouches = 1
         resizePanGestureRecognizer.addTarget(self, action: #selector(handleResizePanGesture))
         resizeButton.addGestureRecognizer(resizePanGestureRecognizer)
     }
     
-    @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+    @objc private func handleDragPanGesture(_ gesture: UIPanGestureRecognizer) {
         let initialPoint = sticker.frame.origin
         let translationPoint = gesture.translation(in: self)
         let changedX = initialPoint.x + translationPoint.x
         let changedY = initialPoint.y + translationPoint.y
         let traslationStickerPoint = CGPoint(x: changedX, y: changedY)
         
-        panGestureRecognizer.setTranslation(.zero, in: self)
+        dragPanGestureRecognizer.setTranslation(.zero, in: self)
         
         let newFrame = CGRect(origin: traslationStickerPoint, size: sticker.frame.size)
         
@@ -209,9 +209,9 @@ final class StickerView: UIView {
     
     private func updatePanGestureState() {
         if sticker.owner == user || sticker.owner == nil {
-            panGestureRecognizer.isEnabled = true
+            dragPanGestureRecognizer.isEnabled = true
         } else {
-            panGestureRecognizer.isEnabled = false
+            dragPanGestureRecognizer.isEnabled = false
         }
     }
     
@@ -235,7 +235,7 @@ final class StickerView: UIView {
     }
     
     func update(with sticker: StickerEntity) {
-        switch panGestureRecognizer.state {
+        switch dragPanGestureRecognizer.state {
         case .began, .changed:
             return
         default:

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
@@ -64,12 +64,12 @@ final class StickerView: UIView {
         
         deleteButton.snp.makeConstraints {
             $0.top.trailing.equalToSuperview()
-            $0.width.height.equalTo(snp.width).multipliedBy(0.3)
+            $0.width.height.equalTo(20)
         }
         
         resizeButton.snp.makeConstraints {
             $0.bottom.trailing.equalToSuperview()
-            $0.width.height.equalTo(snp.width).multipliedBy(0.3)
+            $0.width.height.equalTo(20)
         }
     }
     

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
@@ -8,6 +8,9 @@ protocol StickerViewActionDelegate: AnyObject {
     func stickerView(_ stickerView: StickerView, willBeginDraging sticker: StickerEntity)
     func stickerView(_ stickerView: StickerView, didDrag sticker: StickerEntity)
     func stickerView(_ stickerView: StickerView, didEndDrag sticker: StickerEntity)
+    func stickerView(_ stickerView: StickerView, willBeginResizing sticker: StickerEntity)
+    func stickerView(_ stickerView: StickerView, didResize sticker: StickerEntity)
+    func stickerView(_ stickerView: StickerView, didEndResize sticker: StickerEntity)
 }
 
 final class StickerView: UIView {
@@ -149,13 +152,12 @@ final class StickerView: UIView {
         switch gesture.state {
         case .began:
             updateFrame(to: newFrame)
-//            delegate?.stickerView(self, willBeginDraging: sticker)
+            delegate?.stickerView(self, willBeginResizing: sticker)
         case .changed:
             updateFrame(to: newFrame)
-//            delegate?.stickerView(self, didDrag: sticker)
+            delegate?.stickerView(self, didResize: sticker)
         case .ended:
-            break
-//            delegate?.stickerView(self, didEndDrag: sticker)
+            delegate?.stickerView(self, didEndResize: sticker)
         default: break
         }
     }


### PR DESCRIPTION
## 🤔 배경

- 동시 편집에서 활용될 스티커 확대/축소 기능이 필요했다.

## 📃 작업 내역

- 로컬에서 드래그 제스처로 스티커를 확대/축소 할 수 있게 하였습니다.
- 소유권을 가질 수 있는 스티커만 확대/축소 되게 하였습니다.

## ✅ 리뷰 노트

#### StickerView.swift

- `StickerView`는 다음과 같은 이벤트를 전달해줍니다

```swift
protocol StickerViewActionDelegate: AnyObject {
    func stickerView(_ stickerView: StickerView, willBeginResizing sticker: StickerEntity)
    func stickerView(_ stickerView: StickerView, didResize sticker: StickerEntity)
    func stickerView(_ stickerView: StickerView, didEndResize sticker: StickerEntity)
}
```

#### CanvasScrollView.swift

- `StickerView`의 이벤트를 전달 받습니다.
- `EditPhotoRoomViewController`로 전달해줍니다.

```swift
extension CanvasScrollView: StickerViewActionDelegate {
   ...

    func stickerView(_ stickerView: StickerView, willBeginResizing sticker: StickerEntity) {
        canvasScrollViewDelegate?.canvasScrollView(self, didBeginResize: sticker)
    }
    
    ...
}
```

#### EditPhotoRoomViewController.swift

- `CanvasScrollView`로 부터 받은 이벤트를 ViewModel에게 전달해줍니다.

```swift
extension EditPhotoRoomGuestViewController: CanvasScrollViewDelegate {
    ...

    func canvasScrollView(_ canvasScrollView: CanvasScrollView, didBeginResize sticker: StickerEntity) {
        input.send(.resizeSticker(sticker, .began))
    }
    
    ...
}
```

### 로컬 확대/축소 선반영

#### StickerView.swift

- 선반영을 빠르게 구현하기 위해서 현재 구현된 상태로는 단방향을 어긴 상황입니다 🥲
- 확대/축소의 최대 최소값을 정해주었습니다.(최대 - 128, 최소 - 48)
- 확대/축소가 시작하고 끝나기 전까지는 사용자의 이벤트를 즉각 반영해줍니다.
- 확대/축소가 끝나면 SoT를 반영하기 위해 ViewModel을 다녀온 뒤 최종 Frame을 반영해주도록 하였습니다.

```swift
@objc private func handleResizePanGesture(_ gesture: UIPanGestureRecognizer) {
    ...
    
    resizePanGestureRecognizer.setTranslation(.zero, in: resizeButton)
    let newFrame = CGRect(origin: sticker.frame.origin, size: traslationStickerSize)
    
    switch gesture.state {
    case .began:
        updateFrame(to: newFrame)
        delegate?.stickerView(self, willBeginResizing: sticker)
    case .changed:
        updateFrame(to: newFrame)
        delegate?.stickerView(self, didResize: sticker)
    case .ended:
        delegate?.stickerView(self, didEndResize: sticker)
    default: break
    }
}
```

### 선반영 이후 SoT 적용

#### StickerView.swift

- 이벤트허브로부터 이벤트를 전달받아도 만약 확대/축소 중이라면 해당 스티커의 반영을 무시하게 했습니다.
- 사용자의 확대/축소 이벤트는 정상적으로 이벤트 허브에 전달됩니다.
- 이벤트허브로부터 다시 돌아온 자신의 이벤트는 부자연스러운 동작을 제공해주기에 블락해줍니다.

```swift
func update(with sticker: StickerEntity) {
    switch panGestureRecognizer.state {
    case .began, .changed: return
    default: 
        updateOwner(to: sticker.owner)
        if sticker.owner != user { updateFrame(to: sticker.frame) }
    }
}
```

#### EditPhotoRoomViewModel.swift

`canInteractWithSticker(id: )`: 해당 스티커를 소유할 수 있는지 확인해줍니다. 
`mutateSticker(EventHub/Local)`: 해당 스티커를 이벤트 허브나 로컬에 반영해준다.

- 아래 두개의 이벤트는 이미 Tap을 했을 때 반영되기에 확대/축소에서는 드래그와 다르게 따로 반영해주지 않습니다\

`unlockPreviousSticker(stickerId: )`: 이전에 소유하던 스티커의 Lock을 해제해줍니다.
`lockTappedSticker(id: )`: 스티커의 소유권을 나로 변경하고 Lock을 걸어준다.


```swift
private func handleResizeBegan(sticker: StickerEntity) {
    guard canInteractWithSticker(id: sticker.id) else { return }
    
    mutateStickerEventHub(type: .update, with: sticker)
}

private func handleResizeChanged(sticker: StickerEntity) {
    guard canInteractWithSticker(id: sticker.id) else { return }
    
    mutateStickerEventHub(type: .update, with: sticker)
}

private func handleResizeEnded(sticker: StickerEntity) {
    mutateStickerLocal(type: .update, sticker: sticker)
    
    guard canInteractWithSticker(id: sticker.id) else { return }
    
    mutateStickerEventHub(type: .update, with: sticker)
}
```

## 🎨 스크린샷
| 동시 확대 축소 |
| -------------- |
| ![확대:축소](https://github.com/user-attachments/assets/bce63ff8-c610-46bd-ae6d-d078d7646f87) |


## 🚀 테스트 방법
- 두개의 시뮬레이터에 EditPhotoRoomFeatureDemo를 실행해줍니다.
- 한개의 기기에서 SendOffer를 해줍니다.
- 각각 Host/Guest로 접속합니다
- 다양한 이벤트를 발생해봅니다.
