### PR TITLE
[FEAT/#151] 참가자들의 화면 순서를 동기화 합니다.

### DIFF
--- a/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
+++ b/PhotoGether/DataLayer/PhotoGetherData/PhotoGetherData/ConnectionRepositoryImpl.swift
@@ -282,6 +282,7 @@ extension ConnectionRepositoryImpl {
     private func setLocalUserInfo(entity: RoomOwnerEntity) -> RoomOwnerEntity {
         guard let localUserInfo = localUserInfo(for: entity) else { return entity }
         self.localUserInfo = localUserInfo
+        self.didEnterNewUserSubject.send((localUserInfo, localVideoView))
         return entity
     }
     
@@ -313,7 +314,7 @@ extension ConnectionRepositoryImpl {
     private func localUserInfo(for entity: RoomOwnerEntity) -> UserInfo? {
         return UserInfo(
             id: entity.hostID,
-            nickname: "내가 호스트다",
+            nickname: String(entity.hostID.suffix(4)), // TODO: 서버에서 받아온 닉네임으로 변경 예정
             isHost: true,
             viewPosition: .topLeading,
             roomID: entity.roomID

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/DidEnterNewUserPublisherUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/DidEnterNewUserPublisherUseCaseImpl.swift
@@ -1,12 +1,11 @@
-import Foundation
 import UIKit
+import Combine
 import PhotoGetherDomainInterface
 
-public final class GetLocalVideoUseCaseImpl: GetLocalVideoUseCase {
-    public func execute() -> (UserInfo?, UIView) {
-        return (connectionRepository.localUserInfo, connectionRepository.localVideoView)
+public final class DidEnterNewUserPublisherUseCaseImpl: DidEnterNewUserPublisherUseCase {
+    public func publisher() -> AnyPublisher<(UserInfo, UIView), Never> {
+        return connectionRepository.didEnterNewUserPublisher
     }
-    
     private let connectionRepository: ConnectionRepository
     
     public init(connectionRepository: ConnectionRepository) {

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/GetRemoteVideoUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/GetRemoteVideoUseCaseImpl.swift
@@ -3,16 +3,8 @@ import UIKit
 import PhotoGetherDomainInterface
 
 public final class GetRemoteVideoUseCaseImpl: GetRemoteVideoUseCase {
-    public func execute() -> [UIView] {
-        let sortedClients = connectionRepository.clients
-            .sorted { lhs, rhs in
-                let lhsPosition = lhs.remoteUserInfo?.viewPosition.rawValue ?? Int.max
-                let rhsPosition = rhs.remoteUserInfo?.viewPosition.rawValue ?? Int.max
-                return lhsPosition < rhsPosition
-            }
-            .map { $0.remoteVideoView }
-        
-        return sortedClients
+    public func execute() -> [(UserInfo?, UIView)] {
+        return connectionRepository.clients.map { ($0.remoteUserInfo, $0.remoteVideoView) }
     }
     
     private let connectionRepository: ConnectionRepository

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/UserInfo.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Entity/UserInfo.swift
@@ -9,9 +9,9 @@ public struct UserInfo: Identifiable {
     
     public enum ViewPosition: Int {
         case topLeading
+        case bottomTrailing
         case topTrailing
         case bottomLeading
-        case bottomTrailing
     }
     
     public init(

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/ConnectionRepository.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/Repository/ConnectionRepository.swift
@@ -2,6 +2,10 @@ import UIKit
 import Combine
 
 public protocol ConnectionRepository {
+    var didEnterNewUserPublisher: AnyPublisher<(UserInfo, UIView), Never> { get }
+
+    var localUserInfo: UserInfo? { get }
+
     var clients: [ConnectionClient] { get }
     var localVideoView: UIView { get }
     var capturedLocalVideo: UIImage? { get }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/DidEnterNewUserPublisherUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/DidEnterNewUserPublisherUseCase.swift
@@ -1,0 +1,6 @@
+import UIKit
+import Combine
+
+public protocol DidEnterNewUserPublisherUseCase {
+    func publisher() -> AnyPublisher<(UserInfo, UIView), Never>
+}

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/GetLocalVideoUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/GetLocalVideoUseCase.swift
@@ -2,5 +2,5 @@ import Foundation
 import UIKit
 
 public protocol GetLocalVideoUseCase {
-    func execute() -> UIView
+    func execute() -> (UserInfo?, UIView)
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/GetRemoteVideoUseCase.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomainInterface/UseCase/GetRemoteVideoUseCase.swift
@@ -2,5 +2,5 @@ import Foundation
 import UIKit
 
 public protocol GetRemoteVideoUseCase {
-    func execute() -> [UIView]
+    func execute() -> [(UserInfo?, UIView)]
 }

--- a/PhotoGether/PhotoGether/App/SceneDelegate.swift
+++ b/PhotoGether/PhotoGether/App/SceneDelegate.swift
@@ -82,6 +82,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             connectionRepository: connectionRepository
         )
         
+        let didEnterNewUserPublisherUseCase: DidEnterNewUserPublisherUseCase = DidEnterNewUserPublisherUseCaseImpl(
+            connectionRepository: connectionRepository
+        )
+        
         let photoRoomViewModel: PhotoRoomViewModel = PhotoRoomViewModel(
             captureVideosUseCase: captureVideosUseCase
         )
@@ -97,7 +101,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             sendOfferUseCase: sendOfferUseCase,
             getLocalVideoUseCase: getLocalVideoUseCase,
             getRemoteVideoUseCase: getRemoteVideoUseCase,
-            createRoomUseCase: createRoomUseCase
+            createRoomUseCase: createRoomUseCase,
+            didEnterNewUserPublisherUseCase: didEnterNewUserPublisherUseCase
         )
         
         let waitingRoomViewController: WaitingRoomViewController = WaitingRoomViewController(

--- a/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/Extension/UIViewController+ShowToast.swift
+++ b/PhotoGether/PresentationLayer/BaseFeature/BaseFeature/Extension/UIViewController+ShowToast.swift
@@ -2,7 +2,17 @@ import UIKit
 import DesignSystem
 
 public extension UIViewController {
+    private struct ToastState {
+        static var presentedToast: UIView?
+    }
+    
     func showToast(message: String, duration: TimeInterval = 2.0) {
+        // 이미 토스트가 있다면 제거
+        if let existingToast = ToastState.presentedToast {
+            existingToast.removeFromSuperview()
+            ToastState.presentedToast = nil
+        }
+        
         let padding = UIEdgeInsets(top: 8, left: 20, bottom: 8, right: 20)
         let toastLabel: PTGPaddingLabel = {
             let lbl = PTGPaddingLabel(padding: padding)
@@ -23,6 +33,7 @@ public extension UIViewController {
         }()
 
         view.addSubview(toastLabel)
+        ToastState.presentedToast = toastLabel
         
         let maxWidth: CGFloat = view.frame.width > 0 ? view.frame.width * 0.7 : 300
 

--- a/PhotoGether/PresentationLayer/DesignSystem/DesignSystem/Source/PTGParticipantsGridView.swift
+++ b/PhotoGether/PresentationLayer/DesignSystem/DesignSystem/Source/PTGParticipantsGridView.swift
@@ -105,6 +105,3 @@ extension PTGParticipantsGridView {
         static let itemSpacing: CGFloat = 11
     }
 }
-
-
-

--- a/PhotoGether/PresentationLayer/DesignSystem/DesignSystem/Source/PTGParticipantsGridView.swift
+++ b/PhotoGether/PresentationLayer/DesignSystem/DesignSystem/Source/PTGParticipantsGridView.swift
@@ -1,11 +1,21 @@
 import UIKit
 import SnapKit
 
-public enum ParticipantPosition {
+public enum ParticipantPosition: Int {
     case topLeading
+    case bottomTrailing
     case topTrailing
     case bottomLeading
-    case bottomTrailing
+    
+    public init?(rawValue: Int) {
+        switch rawValue {
+        case 0: self = .topLeading
+        case 1: self = .bottomTrailing
+        case 2: self = .topTrailing
+        case 3: self = .bottomLeading
+        default: return nil
+        }
+    }
 }
 
 public final class PTGParticipantsGridView: UIView {

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/View/WaitingRoomView.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/View/WaitingRoomView.swift
@@ -79,8 +79,7 @@ private extension WaitingRoomView {
     
     func configureUI() {
         self.backgroundColor = PTGColor.gray90.color
-
-        startButton.setTitle(to: StartButtonTitle.one.rawValue)
+        startButton.setTitle(to: "촬영시작")
     }
 }
 

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/EnterLoadingViewController.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewController/EnterLoadingViewController.swift
@@ -48,7 +48,6 @@ public final class EnterLoadingViewController: BaseViewController, ViewControlle
         label.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.top.equalTo(activityIndicator.snp.bottom).offset(10)
-            $0.horizontalEdges.equalToSuperview().inset(20)
         }
     }
     

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewModel/WaitingRoomViewModel.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewModel/WaitingRoomViewModel.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Combine
 import PhotoGetherDomainInterface
+import CoreModule
 
 public final class WaitingRoomViewModel {
     enum Input {
@@ -109,17 +110,17 @@ public final class WaitingRoomViewModel {
     }
     
     private func sendOffer() {
-        let cancellable = sendOfferUseCase.execute().sink { [weak self] completion in
+        _ = sendOfferUseCase.execute().sink { [weak self] completion in
             switch completion {
             case .finished:
                 return
             case .failure(let error):
                 self?.output.send(.shouldShowToast("연결 중 에러가 발생했어요."))
+                PTGLogger.default.log(error.localizedDescription)
             }
         } receiveValue: { [weak self] _ in
             self?.output.send(.shouldShowToast("연결을 시도합니다."))
         }
-        cancellable.cancel()
     }
     
     private func handleLinkButtonDidTap() {

--- a/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewModel/WaitingRoomViewModel.swift
+++ b/PhotoGether/PresentationLayer/WaitingRoomFeature/WaitingRoomFeature/Source/ViewModel/WaitingRoomViewModel.swift
@@ -11,8 +11,8 @@ public final class WaitingRoomViewModel {
     }
     
     enum Output {
-        case localVideo(UIView)
-        case remoteVideos([UIView])
+        case shouldUpdateVideoView(UIView, Int)
+        case shouldUpdateNickname(String, Int)
         case micMuteState(Bool)
         case shouldShowShareSheet(String)
         case navigateToPhotoRoom
@@ -23,6 +23,7 @@ public final class WaitingRoomViewModel {
     private let getLocalVideoUseCase: GetLocalVideoUseCase
     private let getRemoteVideoUseCase: GetRemoteVideoUseCase
     private let createRoomUseCase: CreateRoomUseCase
+    private let didEnterNewUserPublisherUseCase: DidEnterNewUserPublisherUseCase
     
     private var isHost: Bool
     private var cancellables = Set<AnyCancellable>()
@@ -33,13 +34,17 @@ public final class WaitingRoomViewModel {
         sendOfferUseCase: SendOfferUseCase,
         getLocalVideoUseCase: GetLocalVideoUseCase,
         getRemoteVideoUseCase: GetRemoteVideoUseCase,
-        createRoomUseCase: CreateRoomUseCase
+        createRoomUseCase: CreateRoomUseCase,
+        didEnterNewUserPublisherUseCase: DidEnterNewUserPublisherUseCase
     ) {
         self.isHost = isHost
         self.sendOfferUseCase = sendOfferUseCase
         self.getLocalVideoUseCase = getLocalVideoUseCase
         self.getRemoteVideoUseCase = getRemoteVideoUseCase
         self.createRoomUseCase = createRoomUseCase
+        self.didEnterNewUserPublisherUseCase = didEnterNewUserPublisherUseCase
+        
+        bindSideEffects()
     }
     
     func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
@@ -48,6 +53,16 @@ public final class WaitingRoomViewModel {
         }.store(in: &cancellables)
         
         return output.eraseToAnyPublisher()
+    }
+    
+    private func bindSideEffects() {
+        didEnterNewUserPublisherUseCase.publisher().sink { [weak self] userInfo, newUserVideoView in
+            guard let self else { return }
+            self.output.send(.shouldUpdateVideoView(newUserVideoView, userInfo.viewPosition.rawValue))
+            self.output.send(.shouldUpdateNickname(userInfo.nickname, userInfo.viewPosition.rawValue))
+            let message = "\(userInfo.nickname)님이 참가했어요."
+            self.output.send(.shouldShowToast(message))
+        }.store(in: &cancellables)
     }
     
     private func handleEvent(_ event: Input) {
@@ -64,26 +79,47 @@ public final class WaitingRoomViewModel {
     }
     
     private func handleViewDidLoad() {
-        
-        let localVideo = getLocalVideoUseCase.execute()
-        output.send(.localVideo(localVideo))
-        
-        let remoteVideos = getRemoteVideoUseCase.execute()
-        output.send(.remoteVideos(remoteVideos))
-        
+        updateVideoViewAndNickname()
         if !isHost {
-            let cancellable = sendOfferUseCase.execute().sink { [weak self] completion in
-                switch completion {
-                case .finished:
-                    return
-                case .failure(let error):
-                    self?.output.send(.shouldShowToast("연결 중 에러가 발생했어요."))
-                }
-            } receiveValue: { [weak self] _ in
-                self?.output.send(.shouldShowToast("연결을 시도합니다."))
-            }
-            cancellable.cancel()
+            sendOffer()
         }
+    }
+    
+    private func updateVideoViewAndNickname() {
+        if isHost {
+            let localVideoView = getLocalVideoUseCase.execute().1
+            output.send(.shouldUpdateVideoView(localVideoView, 0))
+        } else {
+            let (userInfo, localVideoView) = getLocalVideoUseCase.execute()
+            if let userInfo {
+                output.send(.shouldUpdateVideoView(localVideoView, userInfo.viewPosition.rawValue))
+                output.send(.shouldUpdateNickname(userInfo.nickname, userInfo.viewPosition.rawValue))
+            }
+            
+            let remoteUpdateCancellable = getRemoteVideoUseCase.execute()
+                .publisher
+                .compactMap { ($0.0, $0.1) }
+                .sink { [weak self] userInfo, remoteVideoView in
+                    guard let self, let userInfo else { return }
+                    self.output.send(.shouldUpdateVideoView(remoteVideoView, userInfo.viewPosition.rawValue))
+                    self.output.send(.shouldUpdateNickname(userInfo.nickname, userInfo.viewPosition.rawValue))
+                }
+            remoteUpdateCancellable.cancel()
+        }
+    }
+    
+    private func sendOffer() {
+        let cancellable = sendOfferUseCase.execute().sink { [weak self] completion in
+            switch completion {
+            case .finished:
+                return
+            case .failure(let error):
+                self?.output.send(.shouldShowToast("연결 중 에러가 발생했어요."))
+            }
+        } receiveValue: { [weak self] _ in
+            self?.output.send(.shouldShowToast("연결을 시도합니다."))
+        }
+        cancellable.cancel()
     }
     
     private func handleLinkButtonDidTap() {


### PR DESCRIPTION
## 🤔 배경

서로 다른 순서라면 포즈를 취할 때 어색하기 때문에 순서를 맞춰주는 것이 중요했습니다.

## 📃 작업 내역

- 참가자들 화면 순서 동기화
- 닉네임 표시 (호스트는 Entity가 달라 임시로 설정해두었습니다.)
- Toast 기존 토스트가 남아있으면 제거하고 새로운 Toast의 애니메이션을 시작합니다.


## ✅ 리뷰 노트

리뷰 해줘~~

## 🎨 스크린샷

<img src="https://github.com/user-attachments/assets/28a0131f-ad98-424e-85e8-024e0ddc70d7" width="30%">


## 🚀 테스트 방법
<!--
> 테스트 코드 위치나 테스트 방법에 대해 작성해주세요!
-->
