### PR TITLE
[FIX/#164] 스티커 동시 터치 방지

### DIFF
--- a/PhotoGether/PresentationLayer/DesignSystem/DesignSystem/Source/PTGGrayButton.swift
+++ b/PhotoGether/PresentationLayer/DesignSystem/DesignSystem/Source/PTGGrayButton.swift
@@ -40,6 +40,7 @@ public final class PTGGrayButton: UIButton {
     private func configureUI() {
         backgroundColor = .gray85
         layer.cornerRadius = 12
+        isExclusiveTouch = true
         
         stackView.axis = .horizontal
         stackView.distribution = .equalSpacing

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoHostBottomView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoHostBottomView.swift
@@ -69,5 +69,6 @@ final class EditPhotoHostBottomView: UIView {
         nextButton.backgroundColor = PTGColor.primaryGreen.color
         nextButton.setImage(PTGImage.chevronRightBlack.image, for: .normal)
         nextButton.layer.cornerRadius = 8
+        nextButton.isExclusiveTouch = true
     }
 }

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
@@ -104,6 +104,7 @@ final class StickerView: UIView {
         isUserInteractionEnabled = true
         
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        self.isExclusiveTouch = true
         addGestureRecognizer(tapGesture)
         
         dragPanGestureRecognizer.minimumNumberOfTouches = 1

--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/View/StickerView.swift
@@ -80,6 +80,8 @@ final class StickerView: UIView {
     }
     
     private func configureUI() {
+        isExclusiveTouch = true
+        
         let deleteButtonImage = PTGImage.xmarkIcon.image
         layerView.layer.borderWidth = 2
         layerView.layer.borderColor = PTGColor.primaryGreen.color.cgColor
@@ -88,11 +90,13 @@ final class StickerView: UIView {
         deleteButton.setImage(deleteButtonImage, for: .normal)
         deleteButton.layer.cornerRadius = deleteButton.bounds.width / 2
         deleteButton.clipsToBounds = true
+        deleteButton.isExclusiveTouch = true
         
         let resizeButtonImage = PTGImage.resizeIcon.image
         resizeButton.setImage(resizeButtonImage, for: .normal)
         resizeButton.layer.cornerRadius = resizeButton.bounds.width / 2
         resizeButton.clipsToBounds = true
+        resizeButton.isExclusiveTouch = true
         
         setImage(to: sticker.image)
         updateOwnerUI(owner: sticker.owner)
@@ -104,7 +108,6 @@ final class StickerView: UIView {
         isUserInteractionEnabled = true
         
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
-        self.isExclusiveTouch = true
         addGestureRecognizer(tapGesture)
         
         dragPanGestureRecognizer.minimumNumberOfTouches = 1


### PR DESCRIPTION
## 🤔 배경

- 사용자가 Sticker를 동시에 잡는 문제를 방지함

## 📃 작업 내역

- 스티커를 동시에 못잡게 View의 설정을 수정함

## ✅ 리뷰 노트

view의 속성중 isExclusiveTouch를 켜주었습니다. 해당 옵션은 하나의 View가 롱프레스 되고 있다면 다른 View에 액션을 보내지 못하게 하는 속성입니다.