### PR TITLE
[FIX/#170] 편집화면에서 호스트가 다음화면으로 이동 시 노티피케이션을 두 번 보내는 문제를 해결

### DIFF
--- a/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
+++ b/PhotoGether/PresentationLayer/EditPhotoRoomFeature/EditPhotoRoomFeature/Source/EditPhotoRoomHostViewController.swift
@@ -94,7 +94,6 @@ public class EditPhotoRoomHostViewController: BaseViewController, ViewController
         bottomView.nextButtonTapped
             .throttle(for: 1, scheduler: RunLoop.main, latest: true)
             .sink { [weak self] in
-                NotificationCenter.default.post(name: .navigateToShareRoom, object: nil)
                 self?.showNextView()
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## 🤔 배경
편집화면에서 게스트가 `SharePhotoView`로 이동될 때는 `bindNotification()`을 통해 다음 화면으로 이동합니다.
이때 호스트가 `Notification`을 2번 중복으로 `post`하는 문제가 발생하였습니다.

## 📃 작업 내역

- 호스트가 `Notification`을 2번 중복으로 `post`하는 문제 해결

## ✅ 리뷰 노트
- 중복으로 post하는 코드를 하나 삭제하였습니다.
- `EditPhotoRoomHostViewController` 파일을 확인해주세요.

## 🎨 스크린샷
X

## 🚀 테스트 방법
X