### PR TITLE
[FIX/#177]사진 전달되는 순서 정렬해서 보내기

### DIFF
--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CaptureVideosUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CaptureVideosUseCaseImpl.swift
@@ -1,6 +1,5 @@
 import UIKit
 import PhotoGetherDomainInterface
-import DesignSystem
 
 public final class CaptureVideosUseCaseImpl: CaptureVideosUseCase {
     public func execute() -> [UIImage] {

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CaptureVideosUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CaptureVideosUseCaseImpl.swift
@@ -4,17 +4,11 @@ import DesignSystem
 
 public final class CaptureVideosUseCaseImpl: CaptureVideosUseCase {
     public func execute() -> [UIImage] {
-        guard let localImage = connectionRepository.capturedLocalVideo
-        else { return [
-            PTGImage.temp1.image,
-            PTGImage.temp2.image,
-            PTGImage.temp3.image,
-            PTGImage.temp4.image]
-        }
+        let localImage = connectionRepository.capturedLocalVideo ?? UIImage()
         
-        let localUserImageInfo = [(connectionRepository.localUserInfo, localImage)]
+        let localUserImageInfo = [(connectionRepository.localUserInfo?.viewPosition, localImage)]
         let remoteUserImagesInfo = connectionRepository.clients
-            .map { ($0.remoteUserInfo, $0.captureVideo()) }
+            .map { ($0.remoteUserInfo?.viewPosition, $0.captureVideo()) }
         
         return sortImages(localUserImageInfo + remoteUserImagesInfo)
     }
@@ -25,9 +19,9 @@ public final class CaptureVideosUseCaseImpl: CaptureVideosUseCase {
         self.connectionRepository = connectionRepository
     }
     
-    private func sortImages(_ images: [(user: UserInfo?, image: UIImage)]) -> [UIImage] {
+    private func sortImages(_ images: [(viewPosition: UserInfo.ViewPosition?, image: UIImage)]) -> [UIImage] {
         let convertedArray = images.map {
-            (position: PositionOder(rawValue: $0.user?.viewPosition.rawValue ?? -1),
+            (position: PositionOder(rawValue: $0.viewPosition?.rawValue ?? -1),
              image: $0.image)
         }
         
@@ -41,7 +35,6 @@ public final class CaptureVideosUseCaseImpl: CaptureVideosUseCase {
         return sortedByViewPosition.map { $0.image }
     }
 }
-
 
 // case의 순서는 참가자의 참가 순서에 따른 화면 배치이고 sequence는 이미지 데이터 전달할 때의 배열 순서입니다
 private enum PositionOder: Int {

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CaptureVideosUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CaptureVideosUseCaseImpl.swift
@@ -11,14 +11,51 @@ public final class CaptureVideosUseCaseImpl: CaptureVideosUseCase {
             PTGImage.temp3.image,
             PTGImage.temp4.image]
         }
-        let remoteImages = connectionRepository.clients.map { $0.captureVideo() }
         
-        return [localImage] + remoteImages
+        let localUserImageInfo = [(connectionRepository.localUserInfo, localImage)]
+        let remoteUserImagesInfo = connectionRepository.clients
+            .map { ($0.remoteUserInfo, $0.captureVideo()) }
+        
+        return sortImages(localUserImageInfo + remoteUserImagesInfo)
     }
     
     private let connectionRepository: ConnectionRepository
     
     public init(connectionRepository: ConnectionRepository) {
         self.connectionRepository = connectionRepository
+    }
+    
+    private func sortImages(_ images: [(user: UserInfo?, image: UIImage)]) -> [UIImage] {
+        let convertedArray = images.map {
+            (position: PositionOder(rawValue: $0.user?.viewPosition.rawValue ?? -1),
+             image: $0.image)
+        }
+        
+        // 배열의 2번 인덱스가 마지막 자리이기 때문에 nil일 경우 2로 설정했습니다
+        let sortedByViewPosition = convertedArray.sorted {
+            let lhs = $0.position?.sequence ?? 2
+            let rhs = $1.position?.sequence ?? 2
+            return lhs < rhs
+        }
+        
+        return sortedByViewPosition.map { $0.image }
+    }
+}
+
+
+// case의 순서는 참가자의 참가 순서에 따른 화면 배치이고 sequence는 이미지 데이터 전달할 때의 배열 순서입니다
+private enum PositionOder: Int {
+    case topLeading
+    case bottomTrailing
+    case topTrailing
+    case bottomLeading
+    
+    var sequence: Int {
+        switch self {
+        case .topLeading: 0
+        case .topTrailing: 1
+        case .bottomLeading: 2
+        case .bottomTrailing: 3
+        }
     }
 }

--- a/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CaptureVideosUseCaseImpl.swift
+++ b/PhotoGether/DomainLayer/PhotoGetherDomain/PhotoGetherDomain/UseCaseImpl/CaptureVideosUseCaseImpl.swift
@@ -35,7 +35,7 @@ public final class CaptureVideosUseCaseImpl: CaptureVideosUseCase {
     }
 }
 
-// case의 순서는 참가자의 참가 순서에 따른 화면 배치이고 sequence는 이미지 데이터 전달할 때의 배열 순서입니다
+/// case의 순서는 참가자의 참가 순서에 따른 화면 배치이고 sequence는 이미지 데이터 전달할 때의 배열 순서입니다
 private enum PositionOder: Int {
     case topLeading
     case bottomTrailing

--- a/PhotoGether/PresentationLayer/PhotoRoomFeature/PhotoRoomFeature/Source/View/PhotoRoomBottomView.swift
+++ b/PhotoGether/PresentationLayer/PhotoRoomFeature/PhotoRoomFeature/Source/View/PhotoRoomBottomView.swift
@@ -68,6 +68,10 @@ final class PhotoRoomBottomView: UIView {
     func stopCameraButtonTimer() {
         cameraButton.stopTimer()
     }
+    
+    func highlightCameraButton() {
+        cameraButton.layer.borderColor = PTGColor.primaryGreen.color.cgColor
+    }
 }
 
 extension PhotoRoomBottomView {

--- a/PhotoGether/PresentationLayer/PhotoRoomFeature/PhotoRoomFeature/Source/ViewController/PhotoRoomViewController.swift
+++ b/PhotoGether/PresentationLayer/PhotoRoomFeature/PhotoRoomFeature/Source/ViewController/PhotoRoomViewController.swift
@@ -120,6 +120,7 @@ public final class PhotoRoomViewController: BaseViewController, ViewControllerCo
             switch $0 {
             case .timer(let count):
                 self.photoRoomBottomView.setCameraButtonTimer(count)
+                self.photoRoomBottomView.highlightCameraButton()
             case .timerCompleted(let images, let userInfo):
                 self.photoRoomBottomView.stopCameraButtonTimer()
                 


### PR DESCRIPTION

## 🤔 배경
- PhotoRoom에서 EditRoom으로 넘어갈 때 사진의 순서가 바뀜

## 📃 작업 내역
- UseCase에서 이미지를 정렬해서 보냄

## ✅ 리뷰 노트
1. 기존에는 UIImage(캡쳐된 이미지)만 가져왔지만 정렬을 위해 UserInfo의 ViewPosition을 같이 가져옵니다.
2. ViewPosition의 rawValue는 참가한 순서대로 되어 있기 때문에 PositionOder로 배열에 담길 순서로 바꿔줍니다.
- ViewPosition의 case 순서를 바꿔줄까 생각했지만 서버에서 해당 순서로 인코딩해서 보내주기 때문에 PositionOder로 변환해줬습니다.
3. PositionOder의 sequence 값을 기준으로 배열을 정렬해줍니다.
4. RemoteUserInfo가 nil일 경우 sequence 값을 2로 설정하고 정렬합니다.(2번 인덱스가 마지막 참가자의 자리이기 때문에)
5. LocalUserInfo 가 nil일 경우 임시 이미지 4개가 담겨가던 부분을 수정했습니다. 

## 🎨 스크린샷
| iPhone SE(2세대) | iPhone 14 | iPhone 16 Pro Max |
| -------------- | -------------- | -------------- |
| 스샷 | 스샷 | 스샷 |


## 🚀 테스트 방법